### PR TITLE
migrate to rustc's FxHasher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn",
  "which",
@@ -1149,7 +1149,7 @@ dependencies = [
  "log",
  "num-traits",
  "once_cell",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "spirv",
  "thiserror",
  "unicode-ident",
@@ -1740,6 +1740,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2283,7 +2289,7 @@ dependencies = [
  "portable-atomic",
  "profiling",
  "raw-window-handle",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
  "thiserror",
  "wgpu-core-deps-apple",
@@ -2784,6 +2790,7 @@ version = "0.1.10"
 dependencies = [
  "criterion",
  "proptest",
+ "rustc-hash 2.1.3",
  "thiserror",
  "yscv-onnx",
  "yscv-tensor",
@@ -2797,6 +2804,7 @@ dependencies = [
  "criterion",
  "csv",
  "roxmltree",
+ "rustc-hash 2.1.3",
  "serde",
  "serde_json",
  "thiserror",
@@ -2808,6 +2816,7 @@ dependencies = [
 name = "yscv-examples"
 version = "0.1.10"
 dependencies = [
+ "rustc-hash 2.1.3",
  "thiserror",
  "yscv-autograd",
  "yscv-detect",
@@ -2831,6 +2840,7 @@ dependencies = [
  "image",
  "proptest",
  "rayon",
+ "rustc-hash 2.1.3",
  "thiserror",
  "yscv-cpu",
  "yscv-tensor",
@@ -2852,6 +2862,7 @@ dependencies = [
  "pollster",
  "proptest",
  "rayon",
+ "rustc-hash 2.1.3",
  "tempfile",
  "thiserror",
  "wgpu",
@@ -2864,6 +2875,7 @@ dependencies = [
 name = "yscv-llm-bench"
 version = "0.1.10"
 dependencies = [
+ "rustc-hash 2.1.3",
  "serde",
  "serde_json",
  "thiserror",
@@ -2878,6 +2890,7 @@ version = "0.1.10"
 dependencies = [
  "criterion",
  "image",
+ "rustc-hash 2.1.3",
  "serde",
  "serde_json",
  "thiserror",
@@ -2899,6 +2912,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rayon",
+ "rustc-hash 2.1.3",
  "tempfile",
  "thiserror",
  "yscv-cpu",
@@ -2911,6 +2925,7 @@ dependencies = [
 name = "yscv-optim"
 version = "0.1.10"
 dependencies = [
+ "rustc-hash 2.1.3",
  "thiserror",
  "yscv-autograd",
  "yscv-cpu",
@@ -2921,6 +2936,7 @@ dependencies = [
 name = "yscv-pipeline"
 version = "0.1.10"
 dependencies = [
+ "rustc-hash 2.1.3",
  "serde",
  "thiserror",
  "toml",
@@ -2934,6 +2950,7 @@ dependencies = [
 name = "yscv-quantize-cli"
 version = "0.1.10"
 dependencies = [
+ "rustc-hash 2.1.3",
  "serde",
  "serde_json",
  "thiserror",
@@ -2977,6 +2994,7 @@ name = "yscv-track"
 version = "0.1.10"
 dependencies = [
  "criterion",
+ "rustc-hash 2.1.3",
  "thiserror",
  "yscv-detect",
  "yscv-tensor",
@@ -2993,6 +3011,7 @@ dependencies = [
  "nokhwa",
  "proptest",
  "rayon",
+ "rustc-hash 2.1.3",
  "thiserror",
  "yscv-cpu",
  "yscv-tensor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ keywords = ["computer-vision", "deep-learning", "image-processing", "onnx", "vid
 
 [workspace.dependencies]
 thiserror = "2"
+rustc-hash = "2.1.3"
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/apps/llm-bench/Cargo.toml
+++ b/apps/llm-bench/Cargo.toml
@@ -46,6 +46,7 @@ yscv-kernels = { version = "0.1", path = "../../crates/yscv-kernels", default-fe
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror.workspace = true
+rustc-hash.workspace = true
 
 [lints]
 workspace = true

--- a/apps/llm-bench/src/bin/nchwc_coverage.rs
+++ b/apps/llm-bench/src/bin/nchwc_coverage.rs
@@ -1,3 +1,4 @@
+use rustc_hash::FxHashMap;
 /// NCHWc layout coverage probe — Step 0 of NCHWc-everywhere plan.
 ///
 /// Loads a tracker ONNX model and classifies every Conv op as NCHWc-eligible
@@ -7,8 +8,7 @@
 /// Usage:
 ///   cargo run --release --no-default-features -p yscv-llm-bench --bin nchwc_coverage \
 ///     -- private/private/model.onnx
-use std::collections::{HashMap, HashSet};
-
+use rustc_hash::FxHashSet;
 use yscv_onnx::{OnnxAttribute, OnnxModel, OnnxNode, load_onnx_model_from_file};
 
 fn main() {
@@ -76,8 +76,8 @@ fn is_passthrough(op_type: &str) -> bool {
 /// Build a map: tensor_name → shape, tracing through Identity nodes to
 /// resolve weight-sharing aliases. In Siamese networks, branch1 weights
 /// are Identity(branch0_initializer) — treat them as static weights.
-fn build_effective_initializers(model: &OnnxModel) -> HashMap<String, Vec<usize>> {
-    let mut effective: HashMap<String, Vec<usize>> = model
+fn build_effective_initializers(model: &OnnxModel) -> FxHashMap<String, Vec<usize>> {
+    let mut effective: FxHashMap<String, Vec<usize>> = model
         .initializers
         .iter()
         .map(|(k, v)| (k.clone(), v.shape().to_vec()))
@@ -139,8 +139,8 @@ fn run_coverage_probe(model: &OnnxModel) {
     // Classify each conv op
     let mut eligible = 0usize;
     let mut rejected = 0usize;
-    let mut kind_counts: HashMap<String, usize> = HashMap::new();
-    let mut reject_reasons: HashMap<String, usize> = HashMap::new();
+    let mut kind_counts: FxHashMap<String, usize> = FxHashMap::default();
+    let mut reject_reasons: FxHashMap<String, usize> = FxHashMap::default();
 
     for (_, node) in &conv_ops {
         let weight_name = node.inputs.get(1).map(|s| s.as_str()).unwrap_or("");
@@ -331,7 +331,7 @@ fn run_coverage_probe(model: &OnnxModel) {
     println!();
     println!("QLinearConv ops in model: {}", qlinear_conv.len());
     // Show all non-Conv node op types and counts
-    let mut op_counts: HashMap<&str, usize> = HashMap::new();
+    let mut op_counts: FxHashMap<&str, usize> = FxHashMap::default();
     for node in &model.nodes {
         *op_counts.entry(node.op_type.as_str()).or_default() += 1;
     }
@@ -349,7 +349,7 @@ fn run_coverage_probe(model: &OnnxModel) {
     // Non-passthrough, non-Conv ops require NHWC → insert converter at boundary
 
     // Build tensor → producing node index
-    let mut tensor_producer: HashMap<&str, usize> = HashMap::new();
+    let mut tensor_producer: FxHashMap<&str, usize> = FxHashMap::default();
     for (i, node) in model.nodes.iter().enumerate() {
         for out in &node.outputs {
             if !out.is_empty() {
@@ -421,8 +421,8 @@ fn run_coverage_probe(model: &OnnxModel) {
     // And number of exit converters (nchwc tensors consumed by non-nchwc non-Conv nodes)
 
     // Use effective_weights keys as the "static" set (includes Identity-aliased weights)
-    let static_names: HashSet<&str> = effective_weights.keys().map(|s| s.as_str()).collect();
-    let initializer_names: HashSet<&str> = static_names.clone();
+    let static_names: FxHashSet<&str> = effective_weights.keys().map(|s| s.as_str()).collect();
+    let initializer_names: FxHashSet<&str> = static_names.clone();
     let dynamic_inputs: Vec<&str> = model
         .inputs
         .iter()
@@ -437,7 +437,7 @@ fn run_coverage_probe(model: &OnnxModel) {
     }
 
     // Mark which tensors are in nchwc domain (after potential converter)
-    let mut nchwc_tensors: HashSet<String> = HashSet::new();
+    let mut nchwc_tensors: FxHashSet<String> = FxHashSet::default();
     // Graph inputs start as NHWC; we will count converters needed for them
     // if any eligible node consumes them directly.
 
@@ -446,7 +446,7 @@ fn run_coverage_probe(model: &OnnxModel) {
     let mut internal_boundaries = 0usize;
 
     // Track which dynamic inputs get a converter
-    let mut converted_inputs: HashSet<String> = HashSet::new();
+    let mut converted_inputs: FxHashSet<String> = FxHashSet::default();
 
     for (i, node) in model.nodes.iter().enumerate() {
         if !node_eligible[i] && !matches!(node.op_type.as_str(), "Conv" | "Conv_Relu" | "Conv_SiLU")

--- a/apps/llm-bench/src/bin/quantize_tracker.rs
+++ b/apps/llm-bench/src/bin/quantize_tracker.rs
@@ -35,6 +35,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
+use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use yscv_onnx::quantize::{
     CalibrationCollector, fold_constant_qdq_weights_for_yscv_fast, prune_unused_initializers,
@@ -385,8 +386,8 @@ struct TrackingDelta {
 /// the output maps by shape, then compare argmax cell + the box at the fp32
 /// peak cell. Returns `None` if no 1-channel score map is present.
 fn decoded_tracking_delta(
-    out_fp32: &HashMap<String, Tensor>,
-    out_qdq: &HashMap<String, Tensor>,
+    out_fp32: &FxHashMap<String, Tensor>,
+    out_qdq: &FxHashMap<String, Tensor>,
 ) -> Option<TrackingDelta> {
     let mut score: Option<(&Tensor, &Tensor)> = None;
     let mut bbox: Option<(&Tensor, &Tensor)> = None;

--- a/crates/yscv-detect/Cargo.toml
+++ b/crates/yscv-detect/Cargo.toml
@@ -18,6 +18,7 @@ yscv-onnx = { version = "0.1", path = "../yscv-onnx", optional = true }
 yscv-tensor = { version = "0.1", path = "../yscv-tensor" }
 yscv-video = { version = "0.1", path = "../yscv-video" }
 thiserror.workspace = true
+rustc-hash.workspace = true
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }

--- a/crates/yscv-detect/src/nms.rs
+++ b/crates/yscv-detect/src/nms.rs
@@ -118,9 +118,9 @@ pub fn soft_nms(detections: &mut Vec<Detection>, sigma: f32, score_threshold: f3
 /// each group independently, then merges and returns results sorted by score
 /// descending.
 pub fn batched_nms(detections: &[Detection], iou_threshold: f32) -> Vec<Detection> {
-    use std::collections::HashMap;
+    use rustc_hash::FxHashMap;
 
-    let mut by_class: HashMap<usize, Vec<Detection>> = HashMap::new();
+    let mut by_class: FxHashMap<usize, Vec<Detection>> = FxHashMap::default();
     for det in detections {
         by_class.entry(det.class_id).or_default().push(*det);
     }

--- a/crates/yscv-detect/src/yolo.rs
+++ b/crates/yscv-detect/src/yolo.rs
@@ -360,7 +360,7 @@ pub fn detect_yolov8_onnx(
     img_width: usize,
     config: &YoloConfig,
 ) -> Result<Vec<Detection>, crate::DetectError> {
-    use std::collections::HashMap;
+    use rustc_hash::FxHashMap;
 
     let input_name = model
         .inputs
@@ -373,7 +373,7 @@ pub fn detect_yolov8_onnx(
         image_data.to_vec(),
     )?;
 
-    let mut inputs = HashMap::new();
+    let mut inputs = FxHashMap::default();
     inputs.insert(input_name, tensor);
 
     let outputs = yscv_onnx::run_onnx_model(model, inputs)?;

--- a/crates/yscv-eval/Cargo.toml
+++ b/crates/yscv-eval/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1.0"
 roxmltree = "0.20"
 csv = "1.3"
 thiserror.workspace = true
+rustc-hash.workspace = true
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }

--- a/crates/yscv-eval/src/dataset/coco.rs
+++ b/crates/yscv-eval/src/dataset/coco.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use yscv_detect::{BoundingBox, Detection};
 
@@ -11,7 +11,8 @@ pub(crate) fn build_detection_dataset_from_coco(
     predictions: Vec<CocoPredictionWire>,
 ) -> Result<Vec<DetectionDatasetFrame>, EvalError> {
     let mut frames = Vec::with_capacity(ground_truth.images.len());
-    let mut image_index_by_id = HashMap::with_capacity(ground_truth.images.len());
+    let mut image_index_by_id =
+        FxHashMap::with_capacity_and_hasher(ground_truth.images.len(), FxBuildHasher);
 
     for (frame_idx, image) in ground_truth.images.into_iter().enumerate() {
         if image_index_by_id.insert(image.id, frame_idx).is_some() {

--- a/crates/yscv-eval/src/dataset/helpers.rs
+++ b/crates/yscv-eval/src/dataset/helpers.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::fs;
 use std::io::ErrorKind;
 use std::path::Path;
@@ -18,7 +18,7 @@ pub(crate) fn read_optional_text_file(path: &Path) -> Result<Option<String>, Eva
 
 pub(crate) fn ensure_detection_frame_index(
     frames: &mut Vec<DetectionDatasetFrame>,
-    image_index_by_id: &mut HashMap<String, usize>,
+    image_index_by_id: &mut FxHashMap<String, usize>,
     image_id: &str,
 ) -> usize {
     if let Some(frame_idx) = image_index_by_id.get(image_id) {
@@ -43,9 +43,9 @@ pub(crate) fn parse_image_id_manifest(
     text: &str,
     format: &'static str,
 ) -> Result<Vec<String>, EvalError> {
-    use std::collections::HashSet;
+    use rustc_hash::FxHashSet;
     let mut image_ids = Vec::new();
-    let mut seen = HashSet::new();
+    let mut seen = FxHashSet::default();
     for (line_idx, raw_line) in text.lines().enumerate() {
         let line_no = line_idx + 1;
         let line = raw_line.trim();

--- a/crates/yscv-eval/src/dataset/kitti.rs
+++ b/crates/yscv-eval/src/dataset/kitti.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::path::Path;
 
 use yscv_detect::{BoundingBox, Detection};
@@ -14,7 +14,7 @@ pub(crate) fn load_kitti_label_dirs(
 ) -> Result<Vec<DetectionDatasetFrame>, EvalError> {
     let image_ids = parse_image_id_manifest(manifest_text, "kitti")?;
     let mut frames = Vec::with_capacity(image_ids.len());
-    let mut class_map = HashMap::new();
+    let mut class_map = FxHashMap::default();
 
     for image_id in image_ids {
         let gt_path = kitti_label_path(ground_truth_labels_dir, &image_id);
@@ -51,7 +51,7 @@ fn kitti_label_path(labels_dir: &Path, image_id: &str) -> std::path::PathBuf {
 fn parse_kitti_ground_truth_labels(
     text: &str,
     source: &str,
-    class_map: &mut HashMap<String, usize>,
+    class_map: &mut FxHashMap<String, usize>,
 ) -> Result<Vec<LabeledBox>, EvalError> {
     let mut boxes = Vec::new();
     for (line_idx, raw_line) in text.lines().enumerate() {
@@ -83,7 +83,7 @@ fn parse_kitti_ground_truth_labels(
 fn parse_kitti_predictions(
     text: &str,
     source: &str,
-    class_map: &mut HashMap<String, usize>,
+    class_map: &mut FxHashMap<String, usize>,
 ) -> Result<Vec<Detection>, EvalError> {
     let mut detections = Vec::new();
     for (line_idx, raw_line) in text.lines().enumerate() {
@@ -174,7 +174,7 @@ fn parse_kitti_score(token: &str, source: &str, line_no: usize) -> Result<f32, E
     Ok(score)
 }
 
-fn resolve_kitti_class_id(class_name: &str, class_map: &mut HashMap<String, usize>) -> usize {
+fn resolve_kitti_class_id(class_name: &str, class_map: &mut FxHashMap<String, usize>) -> usize {
     if let Some(&class_id) = class_map.get(class_name) {
         return class_id;
     }

--- a/crates/yscv-eval/src/dataset/openimages.rs
+++ b/crates/yscv-eval/src/dataset/openimages.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use csv::StringRecord;
 use yscv_detect::{BoundingBox, Detection};
@@ -117,8 +117,8 @@ pub(crate) fn parse_and_build_openimages(
     let predictions = parse_openimages_predictions(predictions_csv)?;
 
     let mut frames = Vec::new();
-    let mut image_index_by_id = HashMap::new();
-    let mut class_id_by_label = HashMap::new();
+    let mut image_index_by_id = FxHashMap::default();
+    let mut class_id_by_label = FxHashMap::default();
 
     for entry in ground_truth {
         let frame_idx = ensure_detection_frame_index(
@@ -154,7 +154,7 @@ pub(crate) fn parse_and_build_openimages(
 
 fn resolve_openimages_class_id(
     label_name: &str,
-    class_id_by_label: &mut HashMap<String, usize>,
+    class_id_by_label: &mut FxHashMap<String, usize>,
 ) -> usize {
     if let Some(class_id) = class_id_by_label.get(label_name) {
         return *class_id;

--- a/crates/yscv-eval/src/dataset/widerface.rs
+++ b/crates/yscv-eval/src/dataset/widerface.rs
@@ -1,4 +1,5 @@
-use std::collections::{HashMap, HashSet};
+use rustc_hash::FxHashSet;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use yscv_detect::{BoundingBox, CLASS_ID_FACE, Detection};
 
@@ -23,7 +24,8 @@ pub(crate) fn parse_and_build_widerface(
     let ground_truth_frames = parse_widerface_ground_truth(ground_truth_text)?;
     let prediction_frames = parse_widerface_predictions(predictions_text)?;
 
-    let mut predictions_by_image = HashMap::with_capacity(prediction_frames.len());
+    let mut predictions_by_image =
+        FxHashMap::with_capacity_and_hasher(prediction_frames.len(), FxBuildHasher);
     for frame in prediction_frames {
         if predictions_by_image
             .insert(frame.image_id.clone(), frame.predictions)
@@ -61,7 +63,7 @@ fn parse_widerface_ground_truth(text: &str) -> Result<Vec<WiderFaceGroundTruthFr
     let lines = widerface_significant_lines(text);
     let mut cursor = 0usize;
     let mut frames = Vec::new();
-    let mut seen_ids = HashSet::new();
+    let mut seen_ids = FxHashSet::default();
 
     while cursor < lines.len() {
         let (image_line_no, image_id_raw) = lines[cursor];
@@ -158,7 +160,7 @@ fn parse_widerface_predictions(text: &str) -> Result<Vec<WiderFacePredictionFram
     let lines = widerface_significant_lines(text);
     let mut cursor = 0usize;
     let mut frames = Vec::new();
-    let mut seen_ids = HashSet::new();
+    let mut seen_ids = FxHashSet::default();
 
     while cursor < lines.len() {
         let (image_line_no, image_id_raw) = lines[cursor];

--- a/crates/yscv-eval/src/dataset/yolo.rs
+++ b/crates/yscv-eval/src/dataset/yolo.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use rustc_hash::FxHashSet;
 use std::path::Path;
 
 use yscv_detect::{BoundingBox, Detection};
@@ -42,7 +42,7 @@ pub(crate) fn load_yolo_label_dirs(
 
 fn parse_yolo_manifest(text: &str) -> Result<Vec<YoloManifestEntry>, EvalError> {
     let mut entries = Vec::new();
-    let mut seen_ids = HashSet::new();
+    let mut seen_ids = FxHashSet::default();
     for (line_idx, raw_line) in text.lines().enumerate() {
         let line_no = line_idx + 1;
         let line = raw_line.trim();

--- a/crates/yscv-eval/src/tracking.rs
+++ b/crates/yscv-eval/src/tracking.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use yscv_detect::{BoundingBox, iou};
 use yscv_track::TrackedDetection;
@@ -114,9 +114,9 @@ pub fn idf1(frames: &[TrackingFrame<'_>], config: TrackingEvalConfig) -> Result<
     config.validate()?;
 
     // Count co-occurrences of (gt_object_id, pred_track_id) pairs
-    let mut cooccurrence: HashMap<(u64, u64), u64> = HashMap::new();
-    let mut gt_appearances: HashMap<u64, u64> = HashMap::new();
-    let mut pred_appearances: HashMap<u64, u64> = HashMap::new();
+    let mut cooccurrence: FxHashMap<(u64, u64), u64> = FxHashMap::default();
+    let mut gt_appearances: FxHashMap<u64, u64> = FxHashMap::default();
+    let mut pred_appearances: FxHashMap<u64, u64> = FxHashMap::default();
 
     for frame in frames {
         for gt in frame.ground_truth {
@@ -142,7 +142,7 @@ pub fn idf1(frames: &[TrackingFrame<'_>], config: TrackingEvalConfig) -> Result<
     }
 
     // For each GT object, find the best-matching predicted track (most co-occurrences)
-    let mut best_for_gt: HashMap<u64, (u64, u64)> = HashMap::new(); // gt_id -> (pred_id, count)
+    let mut best_for_gt: FxHashMap<u64, (u64, u64)> = FxHashMap::default(); // gt_id -> (pred_id, count)
     for (&(gt_id, pred_id), &count) in &cooccurrence {
         let entry = best_for_gt.entry(gt_id).or_insert((pred_id, 0));
         if count > entry.1 {
@@ -173,8 +173,8 @@ pub fn hota(frames: &[TrackingFrame<'_>], config: TrackingEvalConfig) -> Result<
     let mut total_fn = 0u64;
 
     // Track which pred_id maps to which gt_id per frame (for association computation)
-    let mut pred_to_gt_per_frame: Vec<HashMap<u64, u64>> = Vec::new();
-    let mut gt_to_pred_per_frame: Vec<HashMap<u64, u64>> = Vec::new();
+    let mut pred_to_gt_per_frame: Vec<FxHashMap<u64, u64>> = Vec::new();
+    let mut gt_to_pred_per_frame: Vec<FxHashMap<u64, u64>> = Vec::new();
 
     for frame in frames {
         let matches = greedy_iou_match(frame, config.iou_threshold);
@@ -186,8 +186,8 @@ pub fn hota(frames: &[TrackingFrame<'_>], config: TrackingEvalConfig) -> Result<
         total_fp += fp_count;
         total_fn += fn_count;
 
-        let mut pred_to_gt = HashMap::new();
-        let mut gt_to_pred = HashMap::new();
+        let mut pred_to_gt = FxHashMap::default();
+        let mut gt_to_pred = FxHashMap::default();
         for &(gt_idx, pred_idx, _) in &matches {
             let gt_id = frame.ground_truth[gt_idx].object_id;
             let pred_id = frame.predictions[pred_idx].track_id;
@@ -263,7 +263,7 @@ pub fn evaluate_tracking(
     let mut false_negatives = 0u64;
     let mut id_switches = 0u64;
     let mut iou_sum = 0.0f32;
-    let mut last_assignment: HashMap<u64, u64> = HashMap::new();
+    let mut last_assignment: FxHashMap<u64, u64> = FxHashMap::default();
 
     for frame in frames {
         total_ground_truth += frame.ground_truth.len() as u64;

--- a/crates/yscv-imgproc/Cargo.toml
+++ b/crates/yscv-imgproc/Cargo.toml
@@ -15,6 +15,7 @@ yscv-tensor = { version = "0.1", path = "../yscv-tensor" }
 yscv-cpu = { version = "0.1", path = "../yscv-cpu" }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "bmp", "webp"] }
 thiserror.workspace = true
+rustc-hash.workspace = true
 rayon = "1.11"
 
 [dev-dependencies]

--- a/crates/yscv-imgproc/src/ops/features.rs
+++ b/crates/yscv-imgproc/src/ops/features.rs
@@ -1586,7 +1586,7 @@ pub fn hough_circles(
         // Generate circle points using angular discretisation
         let circumference = (2.0 * std::f32::consts::PI * r as f32).ceil() as usize;
         let num_steps = circumference.max(36);
-        let mut visited = std::collections::HashSet::new();
+        let mut visited = rustc_hash::FxHashSet::default();
 
         for step in 0..num_steps {
             let angle = 2.0 * std::f32::consts::PI * step as f32 / num_steps as f32;

--- a/crates/yscv-kernels/Cargo.toml
+++ b/crates/yscv-kernels/Cargo.toml
@@ -30,6 +30,7 @@ thiserror.workspace = true
 wgpu = { version = "29", optional = true }
 libc = { version = "0.2", optional = true }
 tempfile = { version = "3", optional = true }
+rustc-hash.workspace = true
 # cblas-sys gives us battle-tested Windows-compatible FFI for cblas_sgemm.
 # Our previous hand-rolled `extern "C"` declaration worked on macOS
 # (Accelerate) and Linux (OpenBLAS) but triggered a numerical bug on

--- a/crates/yscv-kernels/src/ops/conv/gemm_conv.rs
+++ b/crates/yscv-kernels/src/ops/conv/gemm_conv.rs
@@ -460,12 +460,13 @@ fn winograd_cached_weights(
     c_in: usize,
     c_out: usize,
 ) -> std::sync::Arc<WinogradCachedWeights> {
-    use std::collections::HashMap;
+    use rustc_hash::FxHashMap;
     use std::sync::{Arc, Mutex, OnceLock};
 
-    static CACHE: OnceLock<Mutex<HashMap<(u64, usize, usize, usize), Arc<WinogradCachedWeights>>>> =
-        OnceLock::new();
-    let cache = CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    static CACHE: OnceLock<
+        Mutex<FxHashMap<(u64, usize, usize, usize), Arc<WinogradCachedWeights>>>,
+    > = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(FxHashMap::default()));
     let key = (
         winograd_weight_fingerprint(kernel),
         kernel.len(),

--- a/crates/yscv-kernels/src/ops/matmul/pack.rs
+++ b/crates/yscv-kernels/src/ops/matmul/pack.rs
@@ -523,8 +523,8 @@ thread_local! {
     /// fingerprint samples of the B buffer so we don't return a stale pack
     /// when a temporary buffer is reallocated at the same address.
     static PACKED_B_CACHE: std::cell::RefCell<
-        std::collections::HashMap<(usize, usize, usize, u32, u32, u32), std::rc::Rc<PackedB>>,
-    > = std::cell::RefCell::new(std::collections::HashMap::new());
+        rustc_hash::FxHashMap<(usize, usize, usize, u32, u32, u32), std::rc::Rc<PackedB>>,
+    > = std::cell::RefCell::new(rustc_hash::FxHashMap::default());
 }
 
 /// aarch64-only NR=12 packed B companion to `PackedB`. Shares the
@@ -590,11 +590,11 @@ pub(super) fn full_pack_b_nr12(b: &[f32], k: usize, n: usize) -> PackedBNr12 {
 #[cfg(target_arch = "aarch64")]
 thread_local! {
     static PACKED_B_NR12_CACHE: std::cell::RefCell<
-        std::collections::HashMap<
+        rustc_hash::FxHashMap<
             (usize, usize, usize, u32, u32, u32),
             std::rc::Rc<PackedBNr12>,
         >,
-    > = std::cell::RefCell::new(std::collections::HashMap::new());
+    > = std::cell::RefCell::new(rustc_hash::FxHashMap::default());
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -686,8 +686,8 @@ pub(super) fn get_or_pack_b(b: &[f32], k: usize, n: usize) -> std::rc::Rc<Packed
 #[cfg(target_arch = "aarch64")]
 thread_local! {
     static PACKED_B_8X8_CACHE: std::cell::RefCell<
-        std::collections::HashMap<(usize, usize, usize, u32, u32, u32), std::rc::Rc<Vec<f32>>>,
-    > = std::cell::RefCell::new(std::collections::HashMap::new());
+       rustc_hash::FxHashMap<(usize, usize, usize, u32, u32, u32), std::rc::Rc<Vec<f32>>>,
+    > = std::cell::RefCell::new(rustc_hash::FxHashMap::default());
 }
 
 #[cfg(target_arch = "aarch64")]

--- a/crates/yscv-model/Cargo.toml
+++ b/crates/yscv-model/Cargo.toml
@@ -21,6 +21,7 @@ yscv-tensor = { version = "0.1", path = "../yscv-tensor" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror.workspace = true
+rustc-hash.workspace = true
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }

--- a/crates/yscv-model/src/callbacks.rs
+++ b/crates/yscv-model/src/callbacks.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -149,7 +149,7 @@ impl BestModelCheckpoint {
 /// Trait for training callbacks invoked after each epoch.
 pub trait TrainingCallback {
     /// Called after each epoch. Returns true if training should stop.
-    fn on_epoch_end(&mut self, epoch: usize, metrics: &HashMap<String, f32>) -> bool;
+    fn on_epoch_end(&mut self, epoch: usize, metrics: &FxHashMap<String, f32>) -> bool;
 
     /// Called after each batch within an epoch. Default implementation does nothing.
     fn on_batch_end(&mut self, _epoch: usize, _batch: usize, _loss: f32) {}
@@ -164,7 +164,7 @@ impl EarlyStopping {
 }
 
 impl TrainingCallback for EarlyStopping {
-    fn on_epoch_end(&mut self, _epoch: usize, metrics: &HashMap<String, f32>) -> bool {
+    fn on_epoch_end(&mut self, _epoch: usize, metrics: &FxHashMap<String, f32>) -> bool {
         if let Some(&value) = metrics.get(&self.monitor) {
             self.check(value)
         } else {
@@ -182,7 +182,7 @@ impl BestModelCheckpoint {
 }
 
 impl TrainingCallback for BestModelCheckpoint {
-    fn on_epoch_end(&mut self, _epoch: usize, metrics: &HashMap<String, f32>) -> bool {
+    fn on_epoch_end(&mut self, _epoch: usize, metrics: &FxHashMap<String, f32>) -> bool {
         if let Some(&value) = metrics.get(&self.monitor) {
             self.check(value);
         }
@@ -233,7 +233,7 @@ impl MetricsLogger {
 }
 
 impl TrainingCallback for MetricsLogger {
-    fn on_epoch_end(&mut self, epoch: usize, metrics: &HashMap<String, f32>) -> bool {
+    fn on_epoch_end(&mut self, epoch: usize, metrics: &FxHashMap<String, f32>) -> bool {
         let train_loss = metrics
             .get("train_loss")
             .or_else(|| metrics.get("loss"))
@@ -274,7 +274,7 @@ pub fn train_epochs_with_callbacks<F>(
     callbacks: &mut [&mut dyn TrainingCallback],
 ) -> usize
 where
-    F: FnMut(usize) -> HashMap<String, f32>,
+    F: FnMut(usize) -> FxHashMap<String, f32>,
 {
     for epoch in 0..epochs {
         let metrics = train_fn(epoch);

--- a/crates/yscv-model/src/checkpoint_state.rs
+++ b/crates/yscv-model/src/checkpoint_state.rs
@@ -3,7 +3,7 @@
 //! A training checkpoint bundles model parameters and optimizer state into a
 //! single binary file so training can be resumed exactly where it left off.
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::path::Path;
 
 use yscv_tensor::Tensor;
@@ -20,8 +20,8 @@ const OPT_PREFIX: &str = "__opt__.";
 /// to avoid collisions with model weight names.
 pub fn save_training_checkpoint(
     path: &Path,
-    model_weights: &HashMap<String, Tensor>,
-    optimizer_state: &HashMap<String, Tensor>,
+    model_weights: &FxHashMap<String, Tensor>,
+    optimizer_state: &FxHashMap<String, Tensor>,
 ) -> Result<(), ModelError> {
     let mut combined = model_weights.clone();
     for (key, tensor) in optimizer_state {
@@ -35,10 +35,10 @@ pub fn save_training_checkpoint(
 /// Returns `(model_weights, optimizer_state)`.
 pub fn load_training_checkpoint(
     path: &Path,
-) -> Result<(HashMap<String, Tensor>, HashMap<String, Tensor>), ModelError> {
+) -> Result<(FxHashMap<String, Tensor>, FxHashMap<String, Tensor>), ModelError> {
     let all = load_weights(path)?;
-    let mut model_weights = HashMap::new();
-    let mut optimizer_state = HashMap::new();
+    let mut model_weights = FxHashMap::default();
+    let mut optimizer_state = FxHashMap::default();
 
     for (key, tensor) in all {
         if let Some(stripped) = key.strip_prefix(OPT_PREFIX) {
@@ -54,7 +54,7 @@ pub fn load_training_checkpoint(
 /// Flatten SGD velocity buffers into a string-keyed map for serialization.
 ///
 /// Keys: `"sgd.{param_id}.velocity"`
-pub fn sgd_state_to_map(velocity: &HashMap<u64, Tensor>) -> HashMap<String, Tensor> {
+pub fn sgd_state_to_map(velocity: &FxHashMap<u64, Tensor>) -> FxHashMap<String, Tensor> {
     velocity
         .iter()
         .map(|(id, t)| (format!("sgd.{id}.velocity"), t.clone()))
@@ -62,8 +62,8 @@ pub fn sgd_state_to_map(velocity: &HashMap<u64, Tensor>) -> HashMap<String, Tens
 }
 
 /// Restore SGD velocity buffers from a string-keyed map.
-pub fn sgd_state_from_map(map: &HashMap<String, Tensor>) -> HashMap<u64, Tensor> {
-    let mut velocity = HashMap::new();
+pub fn sgd_state_from_map(map: &FxHashMap<String, Tensor>) -> FxHashMap<u64, Tensor> {
+    let mut velocity = FxHashMap::default();
     for (key, tensor) in map {
         if let Some(rest) = key.strip_prefix("sgd.")
             && let Some(id_str) = rest.strip_suffix(".velocity")
@@ -78,8 +78,8 @@ pub fn sgd_state_from_map(map: &HashMap<String, Tensor>) -> HashMap<u64, Tensor>
 /// Flatten Adam/AdamW state into a string-keyed map for serialization.
 ///
 /// Keys: `"adam.{param_id}.m"`, `"adam.{param_id}.v"`, `"adam.{param_id}.step"`
-pub fn adam_state_to_map(state: &[(u64, Tensor, Tensor, u64)]) -> HashMap<String, Tensor> {
-    let mut map = HashMap::new();
+pub fn adam_state_to_map(state: &[(u64, Tensor, Tensor, u64)]) -> FxHashMap<String, Tensor> {
+    let mut map = FxHashMap::default();
     for (id, m, v, step) in state {
         map.insert(format!("adam.{id}.m"), m.clone());
         map.insert(format!("adam.{id}.v"), v.clone());
@@ -95,7 +95,7 @@ pub fn adam_state_to_map(state: &[(u64, Tensor, Tensor, u64)]) -> HashMap<String
 /// Restore Adam/AdamW state from a string-keyed map.
 ///
 /// Returns `Vec<(param_id, first_moment, second_moment, step)>`.
-pub fn adam_state_from_map(map: &HashMap<String, Tensor>) -> Vec<(u64, Tensor, Tensor, u64)> {
+pub fn adam_state_from_map(map: &FxHashMap<String, Tensor>) -> Vec<(u64, Tensor, Tensor, u64)> {
     // Collect unique param IDs from "adam.{id}.m" keys.
     let mut ids: Vec<u64> = map
         .keys()
@@ -131,13 +131,13 @@ mod tests {
         let _ = std::fs::create_dir_all(&dir);
         let path = dir.join("checkpoint.bin");
 
-        let mut model_weights = HashMap::new();
+        let mut model_weights = FxHashMap::default();
         model_weights.insert(
             "layer.0.weight".to_string(),
             Tensor::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap(),
         );
 
-        let mut opt_state = HashMap::new();
+        let mut opt_state = FxHashMap::default();
         opt_state.insert(
             "sgd.0.velocity".to_string(),
             Tensor::from_vec(vec![2, 2], vec![0.1, 0.2, 0.3, 0.4]).unwrap(),
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn test_sgd_state_roundtrip() {
-        let mut velocity = HashMap::new();
+        let mut velocity = FxHashMap::default();
         velocity.insert(
             42u64,
             Tensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]).unwrap(),

--- a/crates/yscv-model/src/dataset/helpers.rs
+++ b/crates/yscv-model/src/dataset/helpers.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::fs;
 use std::path::Path;
 use yscv_tensor::{Tensor, TensorError};
@@ -300,7 +300,7 @@ pub(super) fn class_balanced_sampling_weights(targets: &Tensor) -> Result<Vec<f3
         return Ok(Vec::new());
     }
 
-    let mut class_counts = HashMap::<usize, usize>::new();
+    let mut class_counts = FxHashMap::<usize, usize>::default();
     for class_id in &class_ids {
         let next_count = class_counts
             .get(class_id)

--- a/crates/yscv-model/src/dataset/types.rs
+++ b/crates/yscv-model/src/dataset/types.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use yscv_tensor::Tensor;
 
 use crate::{ImageAugmentationPipeline, ModelError};
@@ -154,7 +154,7 @@ impl SupervisedDataset {
         validate_split_ratios(train_ratio, validation_ratio)?;
 
         let class_labels = class_labels_from_targets(self.targets())?;
-        let mut indices_by_class = HashMap::<usize, Vec<usize>>::new();
+        let mut indices_by_class = FxHashMap::<usize, Vec<usize>>::default();
         for (sample_index, class_id) in class_labels.into_iter().enumerate() {
             indices_by_class
                 .entry(class_id)

--- a/crates/yscv-model/src/hub.rs
+++ b/crates/yscv-model/src/hub.rs
@@ -5,7 +5,7 @@
 //! `$YSCV_CACHE_DIR` (or `~/.yscv/models/` by default) and validated
 //! by expected file size.
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -31,7 +31,7 @@ pub struct HubEntry {
 /// Model hub for downloading and caching pretrained weights.
 pub struct ModelHub {
     cache_dir: PathBuf,
-    registry: HashMap<String, HubEntry>,
+    registry: FxHashMap<String, HubEntry>,
 }
 
 // ---------------------------------------------------------------------------
@@ -56,8 +56,8 @@ pub fn default_cache_dir() -> PathBuf {
 // Registry population
 // ---------------------------------------------------------------------------
 
-fn build_registry() -> HashMap<String, HubEntry> {
-    let mut m = HashMap::new();
+fn build_registry() -> FxHashMap<String, HubEntry> {
+    let mut m = FxHashMap::default();
 
     m.insert(
         "resnet18".into(),
@@ -199,7 +199,7 @@ impl ModelHub {
     }
 
     /// Returns a reference to the internal registry.
-    pub fn registry(&self) -> &HashMap<String, HubEntry> {
+    pub fn registry(&self) -> &FxHashMap<String, HubEntry> {
         &self.registry
     }
 
@@ -260,7 +260,7 @@ impl ModelHub {
 
     /// Downloads (if needed) and loads all tensors from the safetensors
     /// weight file for the given model name.
-    pub fn load_weights(&self, name: &str) -> Result<HashMap<String, Tensor>, ModelError> {
+    pub fn load_weights(&self, name: &str) -> Result<FxHashMap<String, Tensor>, ModelError> {
         let path = self.download_if_missing(name)?;
         load_state_dict(&path)
     }

--- a/crates/yscv-model/src/safetensors.rs
+++ b/crates/yscv-model/src/safetensors.rs
@@ -8,7 +8,7 @@
 //! 3. Remaining bytes — contiguous raw tensor data
 
 use crate::ModelError;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::path::Path;
 use yscv_tensor::Tensor;
 
@@ -64,7 +64,7 @@ pub struct TensorInfo {
 /// A parsed SafeTensors file backed by an in-memory byte buffer.
 pub struct SafeTensorFile {
     /// Parsed tensor metadata, keyed by name.
-    tensors: HashMap<String, TensorInfo>,
+    tensors: FxHashMap<String, TensorInfo>,
     /// The raw data section (everything after the JSON header).
     data: Vec<u8>,
 }
@@ -122,7 +122,7 @@ impl SafeTensorFile {
                 message: format!("invalid JSON header: {e}"),
             })?;
 
-        let mut tensors = HashMap::new();
+        let mut tensors = FxHashMap::default();
         for (name, value) in &header_map {
             if name == "__metadata__" {
                 continue;
@@ -300,9 +300,9 @@ impl SafeTensorFile {
 /// Load all tensors from a SafeTensors file into a name-to-tensor map.
 ///
 /// All tensors are converted to F32.
-pub fn load_state_dict(path: &Path) -> Result<HashMap<String, Tensor>, ModelError> {
+pub fn load_state_dict(path: &Path) -> Result<FxHashMap<String, Tensor>, ModelError> {
     let file = SafeTensorFile::from_file(path)?;
-    let mut map = HashMap::new();
+    let mut map = FxHashMap::default();
     for name in file.tensor_names() {
         let name_owned = name.to_string();
         let tensor = file.load_tensor(name)?;

--- a/crates/yscv-model/src/sequential.rs
+++ b/crates/yscv-model/src/sequential.rs
@@ -1,3 +1,4 @@
+use rustc_hash::FxHashMap;
 use yscv_autograd::{Graph, NodeId};
 use yscv_tensor::Tensor;
 
@@ -930,7 +931,7 @@ impl SequentialModel {
         graph: &'a Graph,
     ) -> Result<Vec<(String, &'a Tensor)>, ModelError> {
         let mut result = Vec::new();
-        let mut type_counts = std::collections::HashMap::<&str, usize>::new();
+        let mut type_counts = FxHashMap::<&str, usize>::default();
 
         for layer in &self.layers {
             match layer {

--- a/crates/yscv-model/src/tensorboard.rs
+++ b/crates/yscv-model/src/tensorboard.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::fs::{self, File};
 use std::io::{BufWriter, Write};
 use std::path::Path;
@@ -213,7 +213,7 @@ impl TensorBoardCallback {
 }
 
 impl TrainingCallback for TensorBoardCallback {
-    fn on_epoch_end(&mut self, _epoch: usize, metrics: &HashMap<String, f32>) -> bool {
+    fn on_epoch_end(&mut self, _epoch: usize, metrics: &FxHashMap<String, f32>) -> bool {
         self.global_step += 1;
         for (tag, &value) in metrics {
             let _ = self.writer.add_scalar(tag, value, self.global_step);
@@ -277,7 +277,7 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
         {
             let mut cb = TensorBoardCallback::new(&dir).unwrap();
-            let mut metrics = HashMap::new();
+            let mut metrics = FxHashMap::default();
             metrics.insert("train_loss".to_string(), 0.42f32);
             let stop = cb.on_epoch_end(0, &metrics);
             assert!(!stop);

--- a/crates/yscv-model/src/tests/callbacks.rs
+++ b/crates/yscv-model/src/tests/callbacks.rs
@@ -1,7 +1,7 @@
 use crate::{
     BestModelCheckpoint, EarlyStopping, MonitorMode, TrainingCallback, train_epochs_with_callbacks,
 };
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::path::PathBuf;
 
 #[test]
@@ -106,7 +106,7 @@ fn test_early_stopping_callback_stops_training() {
     let losses = [1.0_f32, 0.9, 0.8, 0.85, 0.86, 0.87, 0.88, 0.89];
     let trained = train_epochs_with_callbacks(
         |epoch| {
-            let mut m = HashMap::new();
+            let mut m = FxHashMap::default();
             m.insert("loss".to_string(), losses[epoch]);
             m
         },
@@ -124,7 +124,7 @@ fn test_callbacks_full_training() {
     // Loss keeps decreasing every epoch, so early stopping never triggers.
     let trained = train_epochs_with_callbacks(
         |epoch| {
-            let mut m = HashMap::new();
+            let mut m = FxHashMap::default();
             m.insert("loss".to_string(), 1.0 - epoch as f32 * 0.1);
             m
         },
@@ -141,7 +141,7 @@ struct StopAfterCallback {
 }
 
 impl TrainingCallback for StopAfterCallback {
-    fn on_epoch_end(&mut self, epoch: usize, _metrics: &HashMap<String, f32>) -> bool {
+    fn on_epoch_end(&mut self, epoch: usize, _metrics: &FxHashMap<String, f32>) -> bool {
         epoch + 1 >= self.max_epochs
     }
 }
@@ -154,7 +154,7 @@ fn test_multiple_callbacks() {
     let mut stop_after = StopAfterCallback { max_epochs: 3 };
     let trained = train_epochs_with_callbacks(
         |epoch| {
-            let mut m = HashMap::new();
+            let mut m = FxHashMap::default();
             m.insert("loss".to_string(), 1.0 - epoch as f32 * 0.1);
             m
         },

--- a/crates/yscv-model/src/tests/checkpoint.rs
+++ b/crates/yscv-model/src/tests/checkpoint.rs
@@ -100,7 +100,7 @@ fn checkpoint_roundtrip_cnn_layers() {
 
 #[test]
 fn save_load_weights_roundtrip() {
-    let mut tensors = std::collections::HashMap::new();
+    let mut tensors = rustc_hash::FxHashMap::default();
     tensors.insert(
         "layer1.weight".to_string(),
         Tensor::from_vec(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),

--- a/crates/yscv-model/src/tests/data_loader.rs
+++ b/crates/yscv-model/src/tests/data_loader.rs
@@ -71,7 +71,7 @@ fn test_data_loader_multi_worker() {
     assert_eq!(batches.len(), 8);
 
     // Verify all samples are covered (each sample has a unique fill value).
-    let mut seen = std::collections::HashSet::new();
+    let mut seen = rustc_hash::FxHashSet::default();
     for batch in &batches {
         let batch_size = batch.inputs.shape()[0];
         let sample_len = 3;

--- a/crates/yscv-model/src/tests/training_log.rs
+++ b/crates/yscv-model/src/tests/training_log.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use crate::TrainingLog;
 
@@ -6,7 +6,7 @@ use crate::TrainingLog;
 fn test_training_log_records_epochs() {
     let mut log = TrainingLog::new();
     for i in 0..3 {
-        let mut m = HashMap::new();
+        let mut m = FxHashMap::default();
         m.insert("loss".to_string(), 1.0 - i as f32 * 0.1);
         log.log_epoch(m);
     }
@@ -19,7 +19,7 @@ fn test_training_log_get_metric_history() {
     let mut log = TrainingLog::new();
     let losses = [0.9, 0.7, 0.5];
     for &l in &losses {
-        let mut m = HashMap::new();
+        let mut m = FxHashMap::default();
         m.insert("loss".to_string(), l);
         m.insert("acc".to_string(), 1.0 - l);
         log.log_epoch(m);
@@ -41,12 +41,12 @@ fn test_training_log_get_metric_history() {
 fn test_training_log_to_csv() {
     let mut log = TrainingLog::new();
 
-    let mut m1 = HashMap::new();
+    let mut m1 = FxHashMap::default();
     m1.insert("acc".to_string(), 0.8);
     m1.insert("loss".to_string(), 0.5);
     log.log_epoch(m1);
 
-    let mut m2 = HashMap::new();
+    let mut m2 = FxHashMap::default();
     m2.insert("acc".to_string(), 0.9);
     m2.insert("loss".to_string(), 0.3);
     log.log_epoch(m2);

--- a/crates/yscv-model/src/trainer.rs
+++ b/crates/yscv-model/src/trainer.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use yscv_autograd::Graph;
 use yscv_optim::{Adam, AdamW, Sgd};
@@ -101,7 +101,7 @@ impl Default for TrainerConfig {
 pub struct TrainResult {
     pub epochs_trained: usize,
     pub final_loss: f32,
-    pub history: Vec<HashMap<String, f32>>,
+    pub history: Vec<FxHashMap<String, f32>>,
     /// Structured training log with CSV export and per-metric history queries.
     pub log: TrainingLog,
 }
@@ -176,7 +176,7 @@ impl Trainer {
             ..EpochTrainOptions::default()
         };
 
-        let mut history: Vec<HashMap<String, f32>> = Vec::with_capacity(self.config.epochs);
+        let mut history: Vec<FxHashMap<String, f32>> = Vec::with_capacity(self.config.epochs);
         let mut log = TrainingLog::new();
         let mut epochs_trained = 0usize;
         let mut final_loss = f32::NAN;
@@ -185,7 +185,7 @@ impl Trainer {
             ($epoch:expr, $metrics:expr) => {{
                 final_loss = $metrics.mean_loss;
                 epochs_trained = $epoch + 1;
-                let mut epoch_metrics = HashMap::new();
+                let mut epoch_metrics = FxHashMap::default();
                 epoch_metrics.insert("loss".to_string(), $metrics.mean_loss);
                 if let Some((ref val_inputs, ref val_targets)) = val_data {
                     // Use graph-based forward pass (works for all layer types).

--- a/crates/yscv-model/src/training_log.rs
+++ b/crates/yscv-model/src/training_log.rs
@@ -1,9 +1,9 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 /// Records per-epoch training metrics.
 #[derive(Debug, Clone, Default)]
 pub struct TrainingLog {
-    entries: Vec<HashMap<String, f32>>,
+    entries: Vec<FxHashMap<String, f32>>,
 }
 
 impl TrainingLog {
@@ -13,12 +13,12 @@ impl TrainingLog {
     }
 
     /// Record one epoch's metrics.
-    pub fn log_epoch(&mut self, metrics: HashMap<String, f32>) {
+    pub fn log_epoch(&mut self, metrics: FxHashMap<String, f32>) {
         self.entries.push(metrics);
     }
 
     /// All logged entries.
-    pub fn entries(&self) -> &[HashMap<String, f32>] {
+    pub fn entries(&self) -> &[FxHashMap<String, f32>] {
         &self.entries
     }
 
@@ -109,7 +109,7 @@ impl TrainingLog {
     pub fn append_epoch_jsonl(
         path: &std::path::Path,
         epoch: usize,
-        metrics: &HashMap<String, f32>,
+        metrics: &FxHashMap<String, f32>,
     ) -> std::io::Result<()> {
         use std::io::Write;
         let mut file = std::fs::OpenOptions::new()

--- a/crates/yscv-model/src/weight_mapping.rs
+++ b/crates/yscv-model/src/weight_mapping.rs
@@ -5,7 +5,7 @@
 //! translates those names to the yscv `layer.{idx}.*` convention used by
 //! [`crate::zoo::apply_weights`].
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use crate::ModelArchitecture;
 
@@ -21,11 +21,11 @@ pub fn timm_to_yscv_name(timm_name: &str, arch: ModelArchitecture) -> Option<Str
 ///
 /// Unknown keys are silently dropped.
 pub fn remap_state_dict<T: Clone>(
-    state_dict: &HashMap<String, T>,
+    state_dict: &FxHashMap<String, T>,
     arch: ModelArchitecture,
-) -> HashMap<String, T> {
+) -> FxHashMap<String, T> {
     let table = build_mapping_table(arch);
-    let mut out = HashMap::new();
+    let mut out = FxHashMap::default();
     for (timm_name, value) in state_dict {
         if let Some(yscv_name) = table.get(timm_name.as_str()) {
             out.insert(yscv_name.clone(), value.clone());
@@ -38,7 +38,7 @@ pub fn remap_state_dict<T: Clone>(
 // Mapping tables per architecture
 // ---------------------------------------------------------------------------
 
-fn build_mapping_table(arch: ModelArchitecture) -> HashMap<&'static str, String> {
+fn build_mapping_table(arch: ModelArchitecture) -> FxHashMap<&'static str, String> {
     match arch {
         ModelArchitecture::ResNet18 => build_resnet_basic_mapping(&[2, 2, 2, 2]),
         ModelArchitecture::ResNet34 => build_resnet_basic_mapping(&[3, 4, 6, 3]),
@@ -56,7 +56,7 @@ fn build_mapping_table(arch: ModelArchitecture) -> HashMap<&'static str, String>
         | ModelArchitecture::ClipViTB32
         | ModelArchitecture::DINOv2ViTS14
         | ModelArchitecture::WhisperTiny
-        | ModelArchitecture::SAMViTB => HashMap::new(),
+        | ModelArchitecture::SAMViTB => FxHashMap::default(),
     }
 }
 
@@ -68,8 +68,8 @@ fn build_mapping_table(arch: ModelArchitecture) -> HashMap<&'static str, String>
 ///
 /// timm structure: conv1 -> bn1 -> layer{1..4}.{block}.{conv1,bn1,conv2,bn2} -> fc
 /// yscv structure: layer.{idx}.{conv2d,bn,...}
-fn build_resnet_basic_mapping(blocks_per_stage: &[usize]) -> HashMap<&'static str, String> {
-    let mut m = HashMap::new();
+fn build_resnet_basic_mapping(blocks_per_stage: &[usize]) -> FxHashMap<&'static str, String> {
+    let mut m = FxHashMap::default();
 
     // Stem: conv1(7x7) + bn1  →  layer.0 (Conv2d) + layer.1 (BN) + layer.2 (ReLU) + layer.3 (MaxPool)
     insert_static(&mut m, "conv1.weight", "layer.0.conv2d.weight");
@@ -124,8 +124,8 @@ fn build_resnet_basic_mapping(blocks_per_stage: &[usize]) -> HashMap<&'static st
 // ResNet (bottleneck blocks: ResNet50, ResNet101)
 // ---------------------------------------------------------------------------
 
-fn build_resnet_bottleneck_mapping(blocks_per_stage: &[usize]) -> HashMap<&'static str, String> {
-    let mut m = HashMap::new();
+fn build_resnet_bottleneck_mapping(blocks_per_stage: &[usize]) -> FxHashMap<&'static str, String> {
+    let mut m = FxHashMap::default();
 
     // Stem
     insert_static(&mut m, "conv1.weight", "layer.0.conv2d.weight");
@@ -184,8 +184,8 @@ fn build_resnet_bottleneck_mapping(blocks_per_stage: &[usize]) -> HashMap<&'stat
 // VGG
 // ---------------------------------------------------------------------------
 
-fn build_vgg_mapping(blocks_per_stage: &[usize]) -> HashMap<&'static str, String> {
-    let mut m = HashMap::new();
+fn build_vgg_mapping(blocks_per_stage: &[usize]) -> FxHashMap<&'static str, String> {
+    let mut m = FxHashMap::default();
     let mut idx = 0usize;
     let mut timm_feat_idx = 0usize;
 
@@ -232,8 +232,8 @@ fn build_vgg_mapping(blocks_per_stage: &[usize]) -> HashMap<&'static str, String
 // AlexNet
 // ---------------------------------------------------------------------------
 
-fn build_alexnet_mapping() -> HashMap<&'static str, String> {
-    let mut m = HashMap::new();
+fn build_alexnet_mapping() -> FxHashMap<&'static str, String> {
+    let mut m = FxHashMap::default();
 
     // AlexNet timm: features.{0,3,6,8,10} are Conv2d layers
     // yscv build order from zoo.rs: conv→relu→maxpool → conv→relu→maxpool → conv→relu → conv→relu → conv→relu→maxpool → gap→flatten→linear
@@ -276,10 +276,10 @@ fn build_alexnet_mapping() -> HashMap<&'static str, String> {
 // MobileNetV2 (simplified)
 // ---------------------------------------------------------------------------
 
-fn build_mobilenet_v2_mapping() -> HashMap<&'static str, String> {
+fn build_mobilenet_v2_mapping() -> FxHashMap<&'static str, String> {
     // MobileNetV2 has complex inverted residual blocks. Provide stem/head mapping
     // and a generic numbered pattern for the rest.
-    let mut m = HashMap::new();
+    let mut m = FxHashMap::default();
 
     // Stem: conv_stem + bn1
     insert_static(&mut m, "conv_stem.weight", "layer.0.conv2d.weight");
@@ -296,8 +296,8 @@ fn build_mobilenet_v2_mapping() -> HashMap<&'static str, String> {
 // EfficientNet-B0 (simplified)
 // ---------------------------------------------------------------------------
 
-fn build_efficientnet_b0_mapping() -> HashMap<&'static str, String> {
-    let mut m = HashMap::new();
+fn build_efficientnet_b0_mapping() -> FxHashMap<&'static str, String> {
+    let mut m = FxHashMap::default();
 
     // Stem
     insert_static(&mut m, "conv_stem.weight", "layer.0.conv2d.weight");
@@ -310,17 +310,21 @@ fn build_efficientnet_b0_mapping() -> HashMap<&'static str, String> {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Leak a String to get a `&'static str` for use as HashMap key.
+/// Leak a String to get a `&'static str` for use as FxHashMap key.
 /// This is acceptable for a build-once mapping table.
 fn leak(s: &str) -> &'static str {
     Box::leak(s.to_string().into_boxed_str())
 }
 
-fn insert_static(m: &mut HashMap<&'static str, String>, timm: &'static str, yscv: &str) {
+fn insert_static(m: &mut FxHashMap<&'static str, String>, timm: &'static str, yscv: &str) {
     m.insert(timm, yscv.to_string());
 }
 
-fn insert_bn_static(m: &mut HashMap<&'static str, String>, timm_prefix: &'static str, idx: usize) {
+fn insert_bn_static(
+    m: &mut FxHashMap<&'static str, String>,
+    timm_prefix: &'static str,
+    idx: usize,
+) {
     m.insert(
         Box::leak(format!("{timm_prefix}.weight").into_boxed_str()),
         format!("layer.{idx}.bn.gamma"),
@@ -339,7 +343,7 @@ fn insert_bn_static(m: &mut HashMap<&'static str, String>, timm_prefix: &'static
     );
 }
 
-fn insert_bn_dynamic(m: &mut HashMap<&'static str, String>, timm_prefix: &str, idx: usize) {
+fn insert_bn_dynamic(m: &mut FxHashMap<&'static str, String>, timm_prefix: &str, idx: usize) {
     m.insert(
         leak(&format!("{timm_prefix}.weight")),
         format!("layer.{idx}.bn.gamma"),
@@ -402,7 +406,7 @@ mod tests {
 
     #[test]
     fn test_remap_state_dict() {
-        let mut sd: HashMap<String, i32> = HashMap::new();
+        let mut sd: FxHashMap<String, i32> = FxHashMap::default();
         sd.insert("conv1.weight".into(), 42);
         sd.insert("bn1.weight".into(), 7);
         sd.insert("unknown.key".into(), 99);

--- a/crates/yscv-model/src/weights.rs
+++ b/crates/yscv-model/src/weights.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::path::Path;
 
 use yscv_tensor::Tensor;
@@ -19,8 +19,8 @@ struct TensorMeta {
 /// Saves a named set of tensors to a binary file (safetensors-like format).
 ///
 /// Format: [8 bytes: header_len as u64 LE] [header JSON bytes] [raw f32 data].
-pub fn save_weights(path: &Path, tensors: &HashMap<String, Tensor>) -> Result<(), ModelError> {
-    let mut meta_map: HashMap<String, TensorMeta> = HashMap::new();
+pub fn save_weights(path: &Path, tensors: &FxHashMap<String, Tensor>) -> Result<(), ModelError> {
+    let mut meta_map: FxHashMap<String, TensorMeta> = FxHashMap::default();
     let mut raw_data: Vec<u8> = Vec::new();
 
     let mut names: Vec<&String> = tensors.keys().collect();
@@ -64,7 +64,7 @@ pub fn save_weights(path: &Path, tensors: &HashMap<String, Tensor>) -> Result<()
 ///
 /// Reads the entire file into memory. For very large models (>RAM),
 /// consider using memory-mapped I/O or streaming instead.
-pub fn load_weights(path: &Path) -> Result<HashMap<String, Tensor>, ModelError> {
+pub fn load_weights(path: &Path) -> Result<FxHashMap<String, Tensor>, ModelError> {
     let file_data = std::fs::read(path).map_err(|e| ModelError::DatasetLoadIo {
         path: path.display().to_string(),
         message: e.to_string(),
@@ -88,7 +88,7 @@ pub fn load_weights(path: &Path) -> Result<HashMap<String, Tensor>, ModelError> 
             message: e.to_string(),
         }
     })?;
-    let meta_map: HashMap<String, TensorMeta> =
+    let meta_map: FxHashMap<String, TensorMeta> =
         serde_json::from_str(header_str).map_err(|e| ModelError::CheckpointSerialization {
             message: e.to_string(),
         })?;
@@ -96,7 +96,7 @@ pub fn load_weights(path: &Path) -> Result<HashMap<String, Tensor>, ModelError> 
     let data_start = 8 + header_len;
     let raw = &file_data[data_start..];
 
-    let mut tensors = HashMap::new();
+    let mut tensors = FxHashMap::default();
     for (name, meta) in &meta_map {
         if meta.offset + meta.length > raw.len() {
             return Err(ModelError::CheckpointSerialization {
@@ -113,7 +113,7 @@ pub fn load_weights(path: &Path) -> Result<HashMap<String, Tensor>, ModelError> 
 }
 
 /// Lists tensor names and shapes from a weight file without loading data.
-pub fn inspect_weights(path: &Path) -> Result<HashMap<String, Vec<usize>>, ModelError> {
+pub fn inspect_weights(path: &Path) -> Result<FxHashMap<String, Vec<usize>>, ModelError> {
     let file_data = std::fs::read(path).map_err(|e| ModelError::DatasetLoadIo {
         path: path.display().to_string(),
         message: e.to_string(),
@@ -129,7 +129,7 @@ pub fn inspect_weights(path: &Path) -> Result<HashMap<String, Vec<usize>>, Model
             message: e.to_string(),
         }
     })?;
-    let meta_map: HashMap<String, TensorMeta> =
+    let meta_map: FxHashMap<String, TensorMeta> =
         serde_json::from_str(header_str).map_err(|e| ModelError::CheckpointSerialization {
             message: e.to_string(),
         })?;

--- a/crates/yscv-model/src/zoo.rs
+++ b/crates/yscv-model/src/zoo.rs
@@ -1,6 +1,6 @@
 //! Pretrained model zoo: architecture registry, builders, and weight management.
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -454,8 +454,8 @@ impl ModelZoo {
 fn collect_model_tensors(
     model: &SequentialModel,
     graph: &Graph,
-) -> Result<HashMap<String, yscv_tensor::Tensor>, ModelError> {
-    let mut tensors = HashMap::new();
+) -> Result<FxHashMap<String, yscv_tensor::Tensor>, ModelError> {
+    let mut tensors = FxHashMap::default();
     for (idx, layer) in model.layers().iter().enumerate() {
         match layer {
             crate::ModelLayer::Conv2d(l) => {
@@ -500,7 +500,7 @@ fn collect_model_tensors(
 fn apply_weights(
     model: &mut SequentialModel,
     graph: &mut Graph,
-    weights: &HashMap<String, Tensor>,
+    weights: &FxHashMap<String, Tensor>,
 ) -> Result<(), ModelError> {
     for (idx, layer) in model.layers_mut().iter_mut().enumerate() {
         match layer {

--- a/crates/yscv-onnx/Cargo.toml
+++ b/crates/yscv-onnx/Cargo.toml
@@ -26,6 +26,7 @@ yscv-kernels = { version = "0.1", path = "../yscv-kernels", default-features = f
 yscv-tensor = { version = "0.1", path = "../yscv-tensor" }
 yscv-threadpool = { version = "0.1", path = "../yscv-threadpool" }
 thiserror.workspace = true
+rustc-hash.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 metal = { version = "0.18", optional = true }

--- a/crates/yscv-onnx/README.md
+++ b/crates/yscv-onnx/README.md
@@ -23,9 +23,9 @@ let outputs = runner.run(&[("images", &input)])?;
 ## Capabilities
 
 - **Inference API variants**:
-  - `run_onnx_model` (owned `HashMap<String, Tensor>`)
-  - `run_onnx_model_borrowed` (borrowed `HashMap`)
-  - `run_onnx_model_borrowed_slice` (borrowed `&[(&str, &Tensor)]`, no `HashMap` required)
+  - `run_onnx_model` (owned `FxHashMap<String, Tensor>`)
+  - `run_onnx_model_borrowed` (borrowed `FxHashMap`)
+  - `run_onnx_model_borrowed_slice` (borrowed `&[(&str, &Tensor)]`, no `FxHashMap` required)
 - **122 ONNX CPU operators**: Conv, MatMul, Gemm, Relu/LeakyRelu/Sigmoid/Tanh/Gelu/Erf/Mish/HardSwish/Softmax/LogSoftmax, BatchNormalization/LayerNormalization/InstanceNormalization, MaxPool/AveragePool/GlobalAveragePool, Resize/Upsample, Concat/Split/Reshape/Flatten/Transpose/Gather/GatherElements/GatherND/ScatterElements/ScatterND/Slice/Tile/Expand, Cast/Pad/Clip/Where/Identity/CumSum/ArgMax/ArgMin/TopK, DepthToSpace/SpaceToDepth, GridSample/RoiAlign/NonMaxSuppression, full quantized stack (QuantizeLinear/DequantizeLinear/QLinearConv/QLinearMatMul/MatMulInteger/ConvInteger/DynamicQuantizeLinear), trig + hyperbolic, logical, fused `Conv_Relu` / `BatchNormalization_Relu`, … (see the op dispatch in `src/runner/dispatch.rs`)
 - **Graph optimizations**: constant folding, Conv+BN fusion, Conv+Relu fusion, dead node elimination
 - **Runtime fusion**: Conv+SiLU (Conv→Sigmoid→Mul pattern), Conv+Relu, BN+Relu, Gemm+Relu, Add+Relu (in-place with buffer reuse), Conv+Add residual (in-place, buffer reuse), in-place Add (same-shape last-use)

--- a/crates/yscv-onnx/src/cpu_topology.rs
+++ b/crates/yscv-onnx/src/cpu_topology.rs
@@ -106,8 +106,8 @@ fn detect_linux_big_cores() -> Option<Vec<usize>> {
 
 #[cfg(target_os = "linux")]
 fn detect_linux_physical_cores() -> Option<usize> {
-    use std::collections::HashSet;
-    let mut cores: HashSet<(usize, usize)> = HashSet::new();
+    use rustc_hash::FxHashSet;
+    let mut cores: FxHashSet<(usize, usize)> = FxHashSet::default();
     for id in 0..1024usize {
         let cpu_dir = format!("/sys/devices/system/cpu/cpu{id}");
         if !std::path::Path::new(&cpu_dir).exists() {

--- a/crates/yscv-onnx/src/exporter.rs
+++ b/crates/yscv-onnx/src/exporter.rs
@@ -1,5 +1,5 @@
 use prost::Message;
-use std::collections::HashSet;
+use rustc_hash::FxHashSet;
 use yscv_tensor::Tensor;
 
 use crate::error::OnnxError;
@@ -273,8 +273,8 @@ pub fn onnx_model_to_export_graph(model: &crate::loader::OnnxModel) -> OnnxExpor
     }
 }
 
-fn infer_int64_tensor_names(nodes: &[crate::loader::OnnxNode]) -> HashSet<String> {
-    let mut names = HashSet::new();
+fn infer_int64_tensor_names(nodes: &[crate::loader::OnnxNode]) -> FxHashSet<String> {
+    let mut names = FxHashSet::default();
     for node in nodes {
         match node.op_type.as_str() {
             "Reshape" | "Expand" | "Tile" | "Gather" | "GatherElements" | "GatherND" => {

--- a/crates/yscv-onnx/src/loader/mod.rs
+++ b/crates/yscv-onnx/src/loader/mod.rs
@@ -1,6 +1,7 @@
-use std::collections::{HashMap, HashSet};
+use rustc_hash::FxHashSet;
 
 use prost::Message;
+use rustc_hash::FxHashMap;
 use yscv_tensor::Tensor;
 
 use crate::error::OnnxError;
@@ -20,7 +21,7 @@ pub struct OnnxNode {
     pub name: String,
     pub inputs: Vec<String>,
     pub outputs: Vec<String>,
-    pub attributes: HashMap<String, OnnxAttribute>,
+    pub attributes: FxHashMap<String, OnnxAttribute>,
 }
 
 /// Supported ONNX attribute value types.
@@ -38,15 +39,15 @@ pub enum OnnxAttribute {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct RuntimeModelIndex {
     /// Dense slot id per tensor name for TensorEnv hot-path lookups.
-    pub(crate) name_to_id: HashMap<String, usize>,
+    pub(crate) name_to_id: FxHashMap<String, usize>,
     /// Slot ids for weights pre-permuted OIHW -> KHWC.
-    pub(crate) khwc_weight_ids: HashSet<usize>,
+    pub(crate) khwc_weight_ids: FxHashSet<usize>,
     /// Slot ids for depthwise weights pre-permuted [O,1,KH,KW] -> [KH,KW,C,dm].
-    pub(crate) dw_khwc_weight_ids: HashSet<usize>,
+    pub(crate) dw_khwc_weight_ids: FxHashSet<usize>,
     /// Slot ids for grouped-conv weights pre-permuted [O,I/G,KH,KW] -> [O,KH,KW,I/G].
-    pub(crate) group_khwc_weight_ids: HashSet<usize>,
+    pub(crate) group_khwc_weight_ids: FxHashSet<usize>,
     /// Number of graph uses per value name (input edge count).
-    pub(crate) use_counts: HashMap<String, usize>,
+    pub(crate) use_counts: FxHashMap<String, usize>,
     /// Dense use-count table indexed by runtime slot id.
     pub(crate) use_counts_by_id: Vec<usize>,
     /// Lightweight op tags for fast fusion pattern matching at runtime.
@@ -71,23 +72,23 @@ pub(crate) struct RuntimeModelIndex {
     /// inference, skipping both the fingerprint cache lookup AND the pack
     /// itself on the hot path. Only populated for weights whose dispatch
     /// routes through blocked GEMM (pointwise Conv with KHWC layout, MatMul).
-    pub(crate) prepacked_weights: HashMap<String, std::sync::Arc<yscv_kernels::PackedB>>,
+    pub(crate) prepacked_weights: FxHashMap<String, std::sync::Arc<yscv_kernels::PackedB>>,
     /// Same pre-packed weights, but indexed by dense runtime slot id.
     /// Lets hot paths bypass string hashing by using `node_input_ids`.
     pub(crate) prepacked_weights_by_id: Vec<Option<std::sync::Arc<yscv_kernels::PackedB>>>,
     /// Load-time packed RHS matrices for symmetric-int8 QLinearConv /
     /// QLinearMatMul / MatMulInteger fast paths. Keyed by the ONNX
     /// weight tensor input name; shared by every inference.
-    pub(crate) prepacked_i8_weights: HashMap<String, std::sync::Arc<yscv_kernels::PackedI8B>>,
+    pub(crate) prepacked_i8_weights: FxHashMap<String, std::sync::Arc<yscv_kernels::PackedI8B>>,
     /// QLinear depthwise 3x3/5x5 weights packed once as KHWC i8 so runtime can
     /// call the NHWC int8 depthwise kernel without per-inference weight repack.
-    pub(crate) prepacked_i8_depthwise: HashMap<String, std::sync::Arc<Vec<i8>>>,
+    pub(crate) prepacked_i8_depthwise: FxHashMap<String, std::sync::Arc<Vec<i8>>>,
     /// Pre-packed PW-reduce weights and biases for `FusedPwDwPwReduce` actions.
     /// Keyed by `pw_reduce_idx` (the original PW reduce node index). Built at
     /// load time after fusion detection so the runner can call
     /// `fused_pw_expand_dw_pw_reduce_3x3` without per-call weight transposing.
     pub(crate) prepacked_fused_pw_dw_pw_reduce:
-        HashMap<usize, std::sync::Arc<FusedPwDwPwReduceWeights>>,
+        FxHashMap<usize, std::sync::Arc<FusedPwDwPwReduceWeights>>,
     /// NHWC-passthrough eligibility: output tensor names of
     /// `Reshape` nodes whose single consumer is a `Transpose(perm=[0,2,1])`
     /// followed by `MatMul` (i.e. a `FusedTransposeMatMul` chain). For
@@ -95,7 +96,7 @@ pub(crate) struct RuntimeModelIndex {
     /// keep the NHWC tag, since `exec_fused_transpose_matmul` handles
     /// NHWC-flagged inputs via the non-trans matmul path. Built once at
     /// load time after `FusedTransposeMatMul` detection.
-    pub(crate) reshape_nhwc_passthrough_safe: HashSet<String>,
+    pub(crate) reshape_nhwc_passthrough_safe: FxHashSet<String>,
 }
 
 /// Residual-Add metadata for the `FusedPwDwPwReduce` action.
@@ -205,7 +206,7 @@ pub(crate) enum NodeAction {
     /// tensor). The Transpose node is elided at dispatch time: the
     /// MatMul reads the pre-transpose input via a `transA=1` kernel
     /// (`matmul_2d_slices_trans_a`), so no intermediate transposed
-    /// tensor hits the env HashMap or memory. Mirrors ORT's
+    /// tensor hits the env FxHashMap or memory. Mirrors ORT's
     /// `MatmulTransposeFusion` contrib op.
     ///
     /// `transpose_idx` is the Transpose node's index (for profile
@@ -360,19 +361,19 @@ pub struct OnnxModel {
     pub graph_name: String,
     pub inputs: Vec<String>,
     pub outputs: Vec<String>,
-    pub initializers: HashMap<String, Tensor>,
+    pub initializers: FxHashMap<String, Tensor>,
     pub nodes: Vec<OnnxNode>,
     /// Conv weight names that were pre-permuted OIHW → KHWC at load time.
-    pub(crate) khwc_weights: HashSet<String>,
+    pub(crate) khwc_weights: FxHashSet<String>,
     /// Depthwise conv weight names pre-permuted [O,1,KH,KW] → [KH,KW,C,dm] at load time.
-    pub(crate) dw_khwc_weights: HashSet<String>,
+    pub(crate) dw_khwc_weights: FxHashSet<String>,
     /// Grouped conv weight names pre-permuted [O,I/G,KH,KW] → [O,KH,KW,I/G] at load time.
-    pub(crate) group_khwc_weights: HashSet<String>,
+    pub(crate) group_khwc_weights: FxHashSet<String>,
     /// MatMul/Gemm weights packed to INT4 with per-group fp32 scales for
     /// the LLM decode hot path. Keyed by the original initializer name;
     /// the original `initializers` entry is removed when a weight is
     /// packed so dispatch routes through `packed_int4_gemv_dispatch`.
-    pub(crate) packed_int4_weights: HashMap<String, crate::quantize::PackedInt4Weight>,
+    pub(crate) packed_int4_weights: FxHashMap<String, crate::quantize::PackedInt4Weight>,
     /// Precomputed runtime metadata for fast per-inference environment setup.
     pub(crate) runtime_index: RuntimeModelIndex,
 }
@@ -428,7 +429,7 @@ pub fn load_onnx_model(data: &[u8]) -> Result<OnnxModel, OnnxError> {
         .map(|v| v.name.clone().unwrap_or_default())
         .collect();
 
-    let mut initializers = HashMap::new();
+    let mut initializers = FxHashMap::default();
     for init in &graph.initializer {
         let name = init.name.clone().unwrap_or_default();
         let tensor = convert_tensor_proto(init)?;
@@ -437,7 +438,7 @@ pub fn load_onnx_model(data: &[u8]) -> Result<OnnxModel, OnnxError> {
 
     let mut nodes = Vec::new();
     for node_proto in &graph.node {
-        let mut attributes = HashMap::new();
+        let mut attributes = FxHashMap::default();
         for attr in &node_proto.attribute {
             let attr_name = attr.name.clone().unwrap_or_default();
             let value = convert_attribute(attr);
@@ -454,12 +455,12 @@ pub fn load_onnx_model(data: &[u8]) -> Result<OnnxModel, OnnxError> {
         });
     }
 
-    let matmul_rhs_inputs: HashSet<String> = nodes
+    let matmul_rhs_inputs: FxHashSet<String> = nodes
         .iter()
         .filter(|node| node.op_type == "MatMul")
         .filter_map(|node| node.inputs.get(1).cloned())
         .collect();
-    let graph_outputs: HashSet<String> = outputs.iter().cloned().collect();
+    let graph_outputs: FxHashSet<String> = outputs.iter().cloned().collect();
     let mut folded_nodes = Vec::with_capacity(nodes.len());
     for node in nodes {
         let can_fold_const_transpose = node.op_type == "Transpose"
@@ -487,7 +488,7 @@ pub fn load_onnx_model(data: &[u8]) -> Result<OnnxModel, OnnxError> {
 
     // Pre-permute group=1 Conv weights OIHW → KHWC at load time
     // so we don't pay the ~11ms permutation cost on every inference call.
-    let mut khwc_weights = HashSet::new();
+    let mut khwc_weights = FxHashSet::default();
     for node in &nodes {
         if node.op_type != "Conv" || node.inputs.len() < 2 {
             continue;
@@ -526,9 +527,9 @@ pub fn load_onnx_model(data: &[u8]) -> Result<OnnxModel, OnnxError> {
     // feed both CPU and accelerator runners; the accelerator handles its
     // own pre-permute internally if any.
     #[cfg(not(any(feature = "metal-backend", feature = "gpu")))]
-    let mut dw_khwc_weights = HashSet::new();
+    let mut dw_khwc_weights = FxHashSet::default();
     #[cfg(any(feature = "metal-backend", feature = "gpu"))]
-    let dw_khwc_weights = HashSet::new();
+    let dw_khwc_weights = FxHashSet::default();
     #[cfg(not(any(feature = "metal-backend", feature = "gpu")))]
     for node in &nodes {
         if node.op_type != "Conv" || node.inputs.len() < 2 {
@@ -586,9 +587,9 @@ pub fn load_onnx_model(data: &[u8]) -> Result<OnnxModel, OnnxError> {
     // CPU-only builds. This removes per-inference OIHW reordering in grouped
     // fallback path.
     #[cfg(not(any(feature = "metal-backend", feature = "gpu")))]
-    let mut group_khwc_weights = HashSet::new();
+    let mut group_khwc_weights = FxHashSet::default();
     #[cfg(any(feature = "metal-backend", feature = "gpu"))]
-    let group_khwc_weights = HashSet::new();
+    let group_khwc_weights = FxHashSet::default();
     #[cfg(not(any(feature = "metal-backend", feature = "gpu")))]
     for node in &nodes {
         if node.op_type != "Conv" || node.inputs.len() < 2 {
@@ -666,7 +667,7 @@ pub fn load_onnx_model(data: &[u8]) -> Result<OnnxModel, OnnxError> {
         khwc_weights,
         dw_khwc_weights,
         group_khwc_weights,
-        packed_int4_weights: HashMap::new(),
+        packed_int4_weights: FxHashMap::default(),
         runtime_index,
     })
 }

--- a/crates/yscv-onnx/src/loader/runtime_index.rs
+++ b/crates/yscv-onnx/src/loader/runtime_index.rs
@@ -1,18 +1,20 @@
 //! build_runtime_index: the load-time graph optimizer that classifies
 //! each node (NodeKind), plans fusions (NodeAction), and prepacks weights.
 
+use rustc_hash::FxBuildHasher;
+
 use super::*;
 
 pub(super) fn build_runtime_index(
     inputs: &[String],
     outputs: &[String],
-    initializers: &HashMap<String, Tensor>,
+    initializers: &FxHashMap<String, Tensor>,
     nodes: &[OnnxNode],
-    khwc_weights: &HashSet<String>,
-    dw_khwc_weights: &HashSet<String>,
-    group_khwc_weights: &HashSet<String>,
+    khwc_weights: &FxHashSet<String>,
+    dw_khwc_weights: &FxHashSet<String>,
+    group_khwc_weights: &FxHashSet<String>,
 ) -> RuntimeModelIndex {
-    let mut names: HashSet<&str> = HashSet::new();
+    let mut names: FxHashSet<&str> = FxHashSet::default();
     for name in inputs {
         names.insert(name.as_str());
     }
@@ -30,26 +32,26 @@ pub(super) fn build_runtime_index(
             names.insert(name.as_str());
         }
     }
-    let name_to_id: HashMap<String, usize> = names
+    let name_to_id: FxHashMap<String, usize> = names
         .into_iter()
         .enumerate()
         .map(|(id, name)| (name.to_string(), id))
         .collect();
 
-    let khwc_weight_ids: HashSet<usize> = khwc_weights
+    let khwc_weight_ids: FxHashSet<usize> = khwc_weights
         .iter()
         .filter_map(|name| name_to_id.get(name.as_str()).copied())
         .collect();
-    let dw_khwc_weight_ids: HashSet<usize> = dw_khwc_weights
+    let dw_khwc_weight_ids: FxHashSet<usize> = dw_khwc_weights
         .iter()
         .filter_map(|name| name_to_id.get(name.as_str()).copied())
         .collect();
-    let group_khwc_weight_ids: HashSet<usize> = group_khwc_weights
+    let group_khwc_weight_ids: FxHashSet<usize> = group_khwc_weights
         .iter()
         .filter_map(|name| name_to_id.get(name.as_str()).copied())
         .collect();
 
-    let mut use_counts: HashMap<String, usize> = HashMap::new();
+    let mut use_counts: FxHashMap<String, usize> = FxHashMap::default();
     for node in nodes {
         for inp in &node.inputs {
             if !inp.is_empty() {
@@ -80,7 +82,7 @@ pub(super) fn build_runtime_index(
             .filter(|s| !initializers.contains_key(*s))
             .collect();
         if dyn_inputs.len() >= 2 {
-            let mut tensor_branch: HashMap<&str, u8> = HashMap::new();
+            let mut tensor_branch: FxHashMap<&str, u8> = FxHashMap::default();
             tensor_branch.insert(dyn_inputs[0], 0);
             tensor_branch.insert(dyn_inputs[1], 1);
             let mut branches = Vec::with_capacity(nodes.len());
@@ -140,7 +142,7 @@ pub(super) fn build_runtime_index(
         .collect();
 
     // pre-resolve output names to slot IDs. Used by
-    // `env.insert_by_id` on the hot path to skip the HashMap lookup
+    // `env.insert_by_id` on the hot path to skip the FxHashMap lookup
     // inside `resolve_id`. `node_input_ids` was already cached; this
     // extends the same optimisation to output slots.
     let node_output_ids: Vec<Vec<Option<usize>>> = nodes
@@ -159,7 +161,7 @@ pub(super) fn build_runtime_index(
         })
         .collect();
 
-    // Pre-parse Conv attributes to avoid HashMap lookups in hot path.
+    // Pre-parse Conv attributes to avoid FxHashMap lookups in hot path.
     let conv_params: Vec<Option<ConvParams>> = nodes
         .iter()
         .zip(node_kinds.iter())
@@ -284,7 +286,7 @@ pub(super) fn build_runtime_index(
         matches!(perm.as_slice(), [0, 2, 1])
     }
 
-    fn init_scalar(initializers: &HashMap<String, Tensor>, name: &str) -> Option<f32> {
+    fn init_scalar(initializers: &FxHashMap<String, Tensor>, name: &str) -> Option<f32> {
         initializers
             .get(name)
             .and_then(|t| t.data().first())
@@ -294,7 +296,7 @@ pub(super) fn build_runtime_index(
     fn matching_zero_qparams(
         dequant: &OnnxNode,
         quant: &OnnxNode,
-        initializers: &HashMap<String, Tensor>,
+        initializers: &FxHashMap<String, Tensor>,
     ) -> bool {
         if dequant.inputs.len() < 3 || quant.inputs.len() < 3 {
             return false;
@@ -321,7 +323,7 @@ pub(super) fn build_runtime_index(
     /// `Some("dw")` for 3×3/5×5 depthwise (group=c_out=c_in*group), and
     /// `None` otherwise. Mirrors `bench_tracker::qlinear_conv_kind` so the
     /// load-time detector and the static counter agree node-for-node.
-    fn qlc_kind(node: &OnnxNode, initializers: &HashMap<String, Tensor>) -> Option<&'static str> {
+    fn qlc_kind(node: &OnnxNode, initializers: &FxHashMap<String, Tensor>) -> Option<&'static str> {
         if node.op_type != "QLinearConv" {
             return None;
         }
@@ -389,7 +391,7 @@ pub(super) fn build_runtime_index(
     /// chain output zero-point and may be non-zero.
     fn qlc_zps_match_chain(
         node: &OnnxNode,
-        initializers: &HashMap<String, Tensor>,
+        initializers: &FxHashMap<String, Tensor>,
         require_y_zp_zero: bool,
     ) -> bool {
         let x_zp = init_scalar(initializers, &node.inputs[2]);
@@ -408,8 +410,9 @@ pub(super) fn build_runtime_index(
     // Map tensor name → producing node index. Used by the
     // `FusedTransposeMatMul` detection below to walk from a MatMul
     // left-input back to its Transpose producer in O(1).
-    let producers: HashMap<String, usize> = {
-        let mut m: HashMap<String, usize> = HashMap::with_capacity(nodes.len());
+    let producers: FxHashMap<String, usize> = {
+        let mut m: FxHashMap<String, usize> =
+            FxHashMap::with_capacity_and_hasher(nodes.len(), FxBuildHasher);
         for (idx, node) in nodes.iter().enumerate() {
             for out in &node.outputs {
                 if !out.is_empty() {
@@ -1111,13 +1114,13 @@ pub(super) fn build_runtime_index(
     // transpose output's total graph-use count (input edges + model
     // output membership). When every consumer was absorbed, the
     // original Transpose does no useful work and becomes `Skip`.
-    let model_outputs: HashSet<&str> = outputs.iter().map(|s| s.as_str()).collect();
+    let model_outputs: FxHashSet<&str> = outputs.iter().map(|s| s.as_str()).collect();
     let mut fused_refs: Vec<usize> = vec![0; nodes.len()];
     // Plan position of the last `FusedTransposeMatMul` referencing each
     // transpose idx. Used to mark exactly one variant as the cleanup
     // owner so the pre-transpose tensor stays in `env` until every
     // consumer has read it.
-    let mut last_fused_pos: HashMap<usize, usize> = HashMap::new();
+    let mut last_fused_pos: FxHashMap<usize, usize> = FxHashMap::default();
     for (pos, action) in execution_plan.iter().enumerate() {
         if let NodeAction::FusedTransposeMatMul { transpose_idx, .. } = action {
             fused_refs[*transpose_idx] += 1;
@@ -1157,7 +1160,7 @@ pub(super) fn build_runtime_index(
     // set before deciding whether to skip the NHWC→NCHW permute for a
     // Reshape input. Only NHWC-passthrough-safe Reshapes get the
     // optimisation; others continue paying the legacy `ensure_nchw`.
-    let mut reshape_nhwc_passthrough_safe: HashSet<String> = HashSet::new();
+    let mut reshape_nhwc_passthrough_safe: FxHashSet<String> = FxHashSet::default();
     for action in &execution_plan {
         let NodeAction::FusedTransposeMatMul { transpose_idx, .. } = action else {
             continue;
@@ -1202,8 +1205,8 @@ pub(super) fn build_runtime_index(
     // all pointwise Conv weights at model-load, so this check is typically
     // true. Non-pointwise Convs go through 3×3 direct / im2col paths that
     // don't consume packed B — prepack isn't useful there.
-    let mut prepacked_weights: HashMap<String, std::sync::Arc<yscv_kernels::PackedB>> =
-        HashMap::new();
+    let mut prepacked_weights: FxHashMap<String, std::sync::Arc<yscv_kernels::PackedB>> =
+        FxHashMap::default();
     for (i, node) in nodes.iter().enumerate() {
         let Some(cp) = conv_params[i].as_ref() else {
             continue;
@@ -1296,9 +1299,10 @@ pub(super) fn build_runtime_index(
         (k >= 4 && n.is_multiple_of(16)) || (k >= 512 && n >= 1024)
     }
 
-    let mut prepacked_i8_weights: HashMap<String, std::sync::Arc<yscv_kernels::PackedI8B>> =
-        HashMap::new();
-    let mut prepacked_i8_depthwise: HashMap<String, std::sync::Arc<Vec<i8>>> = HashMap::new();
+    let mut prepacked_i8_weights: FxHashMap<String, std::sync::Arc<yscv_kernels::PackedI8B>> =
+        FxHashMap::default();
+    let mut prepacked_i8_depthwise: FxHashMap<String, std::sync::Arc<Vec<i8>>> =
+        FxHashMap::default();
     // Closing-pair `QuantizedDwPw` chains always need the PW weight
     // prepacked because the kernel reads `env.prepacked_i8_b` directly
     // and there is no per-iteration packing fallback. The default
@@ -1309,7 +1313,7 @@ pub(super) fn build_runtime_index(
     // fallback inside `pack_i8_b_for_matmul` handles non-multiples of
     // 16 — the VNNI 4×16 path is just unavailable; the kernel's
     // `int8_matmul_prepacked_dispatch` picks the next-best variant.
-    let chain_pw_weights: std::collections::HashSet<String> = execution_plan
+    let chain_pw_weights: rustc_hash::FxHashSet<String> = execution_plan
         .iter()
         .filter_map(|action| match action {
             NodeAction::QuantizedDwPw { pw_idx, .. } => nodes[*pw_idx].inputs.get(3).cloned(),
@@ -1481,17 +1485,17 @@ pub(super) fn build_runtime_index(
     //
     // Kill switch: `YSCV_FUSED_PW_DW_PW_REDUCE_OFF=1` keeps everything as
     // FusedPwDw and lets the PW reduce stay a separate Conv action.
-    let mut prepacked_fused_pw_dw_pw_reduce: HashMap<
+    let mut prepacked_fused_pw_dw_pw_reduce: FxHashMap<
         usize,
         std::sync::Arc<FusedPwDwPwReduceWeights>,
-    > = HashMap::new();
+    > = FxHashMap::default();
     let fusion_off = std::env::var_os("YSCV_FUSED_PW_DW_PW_REDUCE_OFF").is_some();
     let fusion_debug = std::env::var_os("YSCV_FUSED_PW_DW_PW_REDUCE_DEBUG").is_some();
     if !fusion_off {
         // Walk the execution plan; replace FusedPwDw actions in-place when
         // the next live node is a fusable PW reduce.
         let mut new_plan: Vec<NodeAction> = Vec::with_capacity(execution_plan.len());
-        let mut skip_pw_reduce_actions: HashSet<usize> = HashSet::new();
+        let mut skip_pw_reduce_actions: FxHashSet<usize> = FxHashSet::default();
         let mut fused_count = 0usize;
         let mut pwdw_total = 0usize;
         for action in execution_plan.iter() {

--- a/crates/yscv-onnx/src/optimizer/analyze_nchwc.rs
+++ b/crates/yscv-onnx/src/optimizer/analyze_nchwc.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use crate::loader::OnnxModel;
 
@@ -43,7 +43,7 @@ fn is_nchwc_capable_op(op_type: &str) -> bool {
 
 pub fn analyze_nchwc(model: &OnnxModel) -> NchwcStats {
     let total_nodes = model.nodes.len();
-    let mut op_counts: HashMap<String, usize> = HashMap::new();
+    let mut op_counts: FxHashMap<String, usize> = FxHashMap::default();
     let mut capable_nodes = 0usize;
     let mut chain_lengths: Vec<usize> = Vec::new();
     let mut current_chain = 0usize;
@@ -84,7 +84,7 @@ pub fn analyze_nchwc(model: &OnnxModel) -> NchwcStats {
 
 #[cfg(test)]
 mod nchwc_stats_tests {
-    use std::collections::HashSet;
+    use rustc_hash::FxHashSet;
 
     use super::*;
     use crate::loader::OnnxNode;
@@ -95,7 +95,7 @@ mod nchwc_stats_tests {
             name: name.to_string(),
             inputs: vec![],
             outputs: vec![],
-            attributes: HashMap::new(),
+            attributes: FxHashMap::default(),
         }
     }
 
@@ -107,11 +107,11 @@ mod nchwc_stats_tests {
             graph_name: String::new(),
             inputs: vec![],
             outputs: vec![],
-            initializers: HashMap::new(),
+            initializers: FxHashMap::default(),
             nodes: vec![],
-            khwc_weights: HashSet::new(),
-            dw_khwc_weights: HashSet::new(),
-            group_khwc_weights: HashSet::new(),
+            khwc_weights: FxHashSet::default(),
+            dw_khwc_weights: FxHashSet::default(),
+            group_khwc_weights: FxHashSet::default(),
             packed_int4_weights: Default::default(),
             runtime_index: Default::default(),
         };

--- a/crates/yscv-onnx/src/optimizer/eliminate_dead_code.rs
+++ b/crates/yscv-onnx/src/optimizer/eliminate_dead_code.rs
@@ -1,12 +1,12 @@
-use std::collections::HashSet;
+use rustc_hash::FxHashSet;
 
 use crate::loader::OnnxModel;
 
 /// Removes nodes whose outputs are never consumed by any other node or graph output.
 pub fn eliminate_dead_code(model: &mut OnnxModel) {
     loop {
-        let consumed: HashSet<String> = {
-            let mut set: HashSet<String> = model.outputs.iter().cloned().collect();
+        let consumed: FxHashSet<String> = {
+            let mut set: FxHashSet<String> = model.outputs.iter().cloned().collect();
             for node in &model.nodes {
                 for inp in &node.inputs {
                     if !inp.is_empty() {

--- a/crates/yscv-onnx/src/optimizer/fold_constants.rs
+++ b/crates/yscv-onnx/src/optimizer/fold_constants.rs
@@ -1,4 +1,5 @@
-use std::collections::{HashMap, HashSet};
+use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 
 use yscv_tensor::Tensor;
 
@@ -59,17 +60,17 @@ pub fn fold_constants(model: &mut OnnxModel) {
             graph_name: String::new(),
             inputs: node.inputs.clone(),
             outputs: node.outputs.clone(),
-            initializers: HashMap::new(),
+            initializers: FxHashMap::default(),
             nodes: vec![node.clone()],
-            khwc_weights: HashSet::new(),
-            dw_khwc_weights: HashSet::new(),
-            group_khwc_weights: HashSet::new(),
+            khwc_weights: FxHashSet::default(),
+            dw_khwc_weights: FxHashSet::default(),
+            group_khwc_weights: FxHashSet::default(),
             packed_int4_weights: Default::default(),
             runtime_index: Default::default(),
         };
         mini_model.rebuild_runtime_index();
 
-        let mut inputs: HashMap<String, Tensor> = HashMap::new();
+        let mut inputs: FxHashMap<String, Tensor> = FxHashMap::default();
         for inp in &node.inputs {
             if !inp.is_empty()
                 && let Some(t) = model.initializers.get(inp)

--- a/crates/yscv-onnx/src/optimizer/graph_stats.rs
+++ b/crates/yscv-onnx/src/optimizer/graph_stats.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use crate::loader::OnnxModel;
 
@@ -12,7 +12,7 @@ pub struct GraphStats {
 
 /// Computes summary statistics for an ONNX model graph.
 pub fn graph_stats(model: &OnnxModel) -> GraphStats {
-    let mut op_counts = HashMap::new();
+    let mut op_counts = FxHashMap::default();
     for node in &model.nodes {
         *op_counts.entry(node.op_type.clone()).or_insert(0usize) += 1;
     }

--- a/crates/yscv-onnx/src/optimizer/remove_dropout_nodes.rs
+++ b/crates/yscv-onnx/src/optimizer/remove_dropout_nodes.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use rustc_hash::FxHashSet;
 
 use crate::loader::OnnxModel;
 
@@ -31,7 +31,7 @@ pub fn remove_dropout_nodes(model: &mut OnnxModel) {
         }
     }
 
-    let dropout_names: HashSet<String> = model
+    let dropout_names: FxHashSet<String> = model
         .nodes
         .iter()
         .filter(|n| n.op_type == "Dropout")

--- a/crates/yscv-onnx/src/optimizer/reorder_nodes_for_fusion.rs
+++ b/crates/yscv-onnx/src/optimizer/reorder_nodes_for_fusion.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use crate::loader::OnnxModel;
 
@@ -27,7 +27,8 @@ pub fn reorder_nodes_for_fusion(model: &mut OnnxModel) {
         return;
     }
 
-    let mut producer: HashMap<&str, usize> = HashMap::with_capacity(n);
+    let mut producer: FxHashMap<&str, usize> =
+        FxHashMap::with_capacity_and_hasher(n, FxBuildHasher);
     for (i, node) in model.nodes.iter().enumerate() {
         for out in &node.outputs {
             producer.insert(out.as_str(), i);

--- a/crates/yscv-onnx/src/optimizer/strip_qdq_within_fusion_chains.rs
+++ b/crates/yscv-onnx/src/optimizer/strip_qdq_within_fusion_chains.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use crate::loader::{OnnxModel, OnnxNode};
 
@@ -21,7 +21,7 @@ pub fn strip_qdq_within_fusion_chains(model: &mut OnnxModel) -> usize {
     let conv_like = |op: &str| matches!(op, "Conv" | "Conv_Relu" | "MatMul" | "Gemm");
 
     let mut to_remove: Vec<usize> = Vec::new();
-    let mut renames: HashMap<String, String> = HashMap::new();
+    let mut renames: FxHashMap<String, String> = FxHashMap::default();
 
     for (i, dq) in model.nodes.iter().enumerate() {
         if dq.op_type != "DequantizeLinear" || dq.inputs.is_empty() || dq.outputs.is_empty() {
@@ -102,7 +102,7 @@ pub fn strip_qdq_within_fusion_chains(model: &mut OnnxModel) -> usize {
 
 #[cfg(test)]
 mod strip_qdq_tests {
-    use std::collections::HashSet;
+    use rustc_hash::FxHashSet;
 
     use super::*;
 
@@ -112,7 +112,7 @@ mod strip_qdq_tests {
             name: name.to_string(),
             inputs: ins.iter().map(|s| s.to_string()).collect(),
             outputs: outs.iter().map(|s| s.to_string()).collect(),
-            attributes: HashMap::new(),
+            attributes: FxHashMap::default(),
         }
     }
 
@@ -124,11 +124,11 @@ mod strip_qdq_tests {
             graph_name: String::new(),
             inputs: vec!["x".into()],
             outputs: vec!["y".into()],
-            initializers: HashMap::new(),
+            initializers: FxHashMap::default(),
             nodes,
-            khwc_weights: HashSet::new(),
-            dw_khwc_weights: HashSet::new(),
-            group_khwc_weights: HashSet::new(),
+            khwc_weights: FxHashSet::default(),
+            dw_khwc_weights: FxHashSet::default(),
+            group_khwc_weights: FxHashSet::default(),
             packed_int4_weights: Default::default(),
             runtime_index: Default::default(),
         }

--- a/crates/yscv-onnx/src/quantize/calibrate.rs
+++ b/crates/yscv-onnx/src/quantize/calibrate.rs
@@ -26,7 +26,7 @@
 //! load, so non-calibration inference pays only that one branch in the
 //! tensor-insertion path.
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -172,8 +172,8 @@ impl Histogram {
 }
 
 struct Inner {
-    per_tensor: Mutex<HashMap<String, MinMax>>,
-    histograms: Mutex<HashMap<String, Histogram>>,
+    per_tensor: Mutex<FxHashMap<String, MinMax>>,
+    histograms: Mutex<FxHashMap<String, Histogram>>,
     histogram_enabled: AtomicBool,
 }
 
@@ -194,8 +194,8 @@ impl CalibrationCollector {
     pub fn new() -> Self {
         Self {
             inner: Arc::new(Inner {
-                per_tensor: Mutex::new(HashMap::new()),
-                histograms: Mutex::new(HashMap::new()),
+                per_tensor: Mutex::new(FxHashMap::default()),
+                histograms: Mutex::new(FxHashMap::default()),
                 histogram_enabled: AtomicBool::new(false),
             }),
         }
@@ -213,7 +213,7 @@ impl CalibrationCollector {
 
     /// Snapshot of aggregated per-tensor histograms. Empty when
     /// [`Self::enable_histograms`] was never set.
-    pub fn histograms(&self) -> HashMap<String, Histogram> {
+    pub fn histograms(&self) -> FxHashMap<String, Histogram> {
         self.inner
             .histograms
             .lock()
@@ -239,7 +239,7 @@ impl CalibrationCollector {
     /// Snapshot of aggregated per-tensor statistics. Cheap clone of the
     /// internal map; the collector continues recording into the same
     /// state if a scope is still active.
-    pub fn snapshot(&self) -> HashMap<String, MinMax> {
+    pub fn snapshot(&self) -> FxHashMap<String, MinMax> {
         self.inner
             .per_tensor
             .lock()

--- a/crates/yscv-onnx/src/quantize/mod.rs
+++ b/crates/yscv-onnx/src/quantize/mod.rs
@@ -25,7 +25,7 @@ pub use rewriter::{
     rewrite_to_qlinear,
 };
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use yscv_tensor::Tensor;
 
@@ -63,7 +63,7 @@ pub fn quantize_weights_int4(model: &mut OnnxModel) -> Result<(), OnnxError> {
         return Ok(());
     }
 
-    let mut new_initializers: HashMap<String, Tensor> = HashMap::new();
+    let mut new_initializers: FxHashMap<String, Tensor> = FxHashMap::default();
     let mut dequant_nodes: Vec<(String, OnnxNode)> = Vec::new();
 
     for name in &weight_names {
@@ -158,7 +158,7 @@ pub fn quantize_weights_int4(model: &mut OnnxModel) -> Result<(), OnnxError> {
             inputs: vec![quant_name, scale_name, zp_name],
             outputs: vec![name.clone()],
             attributes: {
-                let mut attrs = HashMap::new();
+                let mut attrs = FxHashMap::default();
                 // axis=0 for per-channel dequantization
                 attrs.insert("axis".to_string(), OnnxAttribute::Int(0));
                 attrs
@@ -202,7 +202,7 @@ mod tests {
             inputs: vec!["input".to_string()],
             outputs: vec!["output".to_string()],
             initializers: {
-                let mut m = HashMap::new();
+                let mut m = FxHashMap::default();
                 m.insert("conv_weight".to_string(), weight);
                 m
             },
@@ -211,7 +211,7 @@ mod tests {
                 name: "conv0".to_string(),
                 inputs: vec!["input".to_string(), "conv_weight".to_string()],
                 outputs: vec!["output".to_string()],
-                attributes: HashMap::new(),
+                attributes: FxHashMap::default(),
             }],
             khwc_weights: Default::default(),
             dw_khwc_weights: Default::default(),
@@ -266,7 +266,7 @@ mod tests {
             inputs: vec![],
             outputs: vec![],
             initializers: {
-                let mut m = HashMap::new();
+                let mut m = FxHashMap::default();
                 m.insert("bias".to_string(), bias);
                 m
             },

--- a/crates/yscv-onnx/src/quantize/packed_int4.rs
+++ b/crates/yscv-onnx/src/quantize/packed_int4.rs
@@ -176,16 +176,16 @@ fn collect_packing_candidates(nodes: &[OnnxNode]) -> Vec<Candidate> {
 mod tests {
     use super::*;
     use crate::loader::{OnnxAttribute, OnnxNode};
-    use std::collections::HashMap;
+    use rustc_hash::FxHashMap;
     use yscv_tensor::Tensor;
 
     fn synth_model(weight_shape: Vec<usize>, weight_data: Vec<f32>, op: &str) -> OnnxModel {
-        let mut initializers = HashMap::new();
+        let mut initializers = FxHashMap::default();
         initializers.insert(
             "w".to_string(),
             Tensor::from_vec(weight_shape, weight_data).unwrap(),
         );
-        let mut attrs = HashMap::new();
+        let mut attrs = FxHashMap::default();
         if op == "Gemm" {
             attrs.insert("transB".to_string(), OnnxAttribute::Int(1));
         }

--- a/crates/yscv-onnx/src/quantize/rewriter.rs
+++ b/crates/yscv-onnx/src/quantize/rewriter.rs
@@ -1,7 +1,7 @@
 //! Rewrite an fp32 ONNX model into QDQ- or QLinear-format quantized models.
 //!
 //! Given a calibrated `OnnxModel` (fp32 weights, fp32 activations) plus a
-//! [`HashMap<String, MinMax>`] of per-tensor activation statistics
+//! [`FxHashMap<String, MinMax>`] of per-tensor activation statistics
 //! collected via [`super::calibrate::CalibrationCollector`], inserts
 //! `QuantizeLinear` / `DequantizeLinear` (QDQ) pairs around every
 //! Conv / MatMul / Gemm node and quantizes their weight initializers
@@ -26,7 +26,8 @@
 //! handles the "weight-only" PTQ mode for users with no calibration
 //! dataset.
 
-use std::collections::{HashMap, HashSet};
+use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 
 use yscv_tensor::Tensor;
 
@@ -58,19 +59,19 @@ const QUANTIZABLE_OP_TYPES: &[&str] = &["Conv", "MatMul", "Gemm"];
 /// under int8 — in fp32, while the backbone Convs still quantize.
 pub fn rewrite_to_qdq(
     model: &mut OnnxModel,
-    activation_stats: &HashMap<String, MinMax>,
+    activation_stats: &FxHashMap<String, MinMax>,
     keep_fp32: &[String],
 ) -> Result<(), OnnxError> {
-    let mut new_initializers: HashMap<String, Tensor> = HashMap::new();
+    let mut new_initializers: FxHashMap<String, Tensor> = FxHashMap::default();
     // Weight-dequant nodes consume only constant initialisers and are
     // safe to prepend (their inputs are always available). Activation
     // Q/DQ nodes must run AFTER their producer node, so we collect
     // them per-consumer-index and splice them into the node list
     // immediately before each consumer.
     let mut weight_dequant_prefix: Vec<OnnxNode> = Vec::new();
-    let mut act_qdq_inserts: HashMap<usize, Vec<OnnxNode>> = HashMap::new();
-    let mut input_renames: HashMap<(usize, usize), String> = HashMap::new();
-    let mut emitted_act_qdq: HashMap<String, String> = HashMap::new();
+    let mut act_qdq_inserts: FxHashMap<usize, Vec<OnnxNode>> = FxHashMap::default();
+    let mut input_renames: FxHashMap<(usize, usize), String> = FxHashMap::default();
+    let mut emitted_act_qdq: FxHashMap<String, String> = FxHashMap::default();
     // map (node_idx, input_idx) -> new input name
 
     for (node_idx, node) in model.nodes.iter().enumerate() {
@@ -137,14 +138,14 @@ pub fn rewrite_to_qdq(
                             name: q_node_name,
                             inputs: vec![act_name.clone(), scale_init.clone(), zp_init.clone()],
                             outputs: vec![q_out.clone()],
-                            attributes: HashMap::new(),
+                            attributes: FxHashMap::default(),
                         },
                         OnnxNode {
                             op_type: "DequantizeLinear".to_string(),
                             name: dq_node_name,
                             inputs: vec![q_out, scale_init, zp_init],
                             outputs: vec![dq_out.clone()],
-                            attributes: HashMap::new(),
+                            attributes: FxHashMap::default(),
                         },
                     ];
                     act_qdq_inserts
@@ -211,9 +212,9 @@ pub fn rewrite_to_qdq(
 /// existing yscv QLinear kernels can run the subset they support.
 pub fn rewrite_to_qlinear(
     model: &mut OnnxModel,
-    activation_stats: &HashMap<String, MinMax>,
+    activation_stats: &FxHashMap<String, MinMax>,
 ) -> Result<(), OnnxError> {
-    let mut new_initializers: HashMap<String, Tensor> = HashMap::new();
+    let mut new_initializers: FxHashMap<String, Tensor> = FxHashMap::default();
     let mut new_nodes = Vec::with_capacity(model.nodes.len() * 3);
     let original_nodes = std::mem::take(&mut model.nodes);
     let mut rewritten = 0usize;
@@ -272,7 +273,7 @@ pub fn rewrite_to_qlinear(
 pub fn fold_constant_qdq_weights_for_yscv_fast(model: &mut OnnxModel) -> Result<usize, OnnxError> {
     let mut folded = 0usize;
     let mut remove = vec![false; model.nodes.len()];
-    let mut new_initializers = HashMap::new();
+    let mut new_initializers = FxHashMap::default();
     for (idx, node) in model.nodes.iter().enumerate() {
         if node.op_type != "DequantizeLinear" || node.inputs.len() < 2 || node.outputs.len() != 1 {
             continue;
@@ -318,7 +319,7 @@ pub fn fold_constant_qdq_weights_for_yscv_fast(model: &mut OnnxModel) -> Result<
 /// become dead graph baggage; pruning them keeps exported models quiet in ORT
 /// and avoids reload-time initializer indexing work.
 pub fn prune_unused_initializers(model: &mut OnnxModel) -> usize {
-    let mut used: HashSet<&str> = HashSet::new();
+    let mut used: FxHashSet<&str> = FxHashSet::default();
     for node in &model.nodes {
         for input in &node.inputs {
             used.insert(input.as_str());
@@ -348,7 +349,7 @@ pub fn prune_unused_initializers(model: &mut OnnxModel) -> usize {
 fn quantize_weight_into(
     weight_name: &str,
     weight: &Tensor,
-    new_initializers: &mut HashMap<String, Tensor>,
+    new_initializers: &mut FxHashMap<String, Tensor>,
     node_prefix: &mut Vec<OnnxNode>,
 ) -> Result<(), OnnxError> {
     let shape = weight.shape();
@@ -411,7 +412,7 @@ fn quantize_weight_into(
         })?,
     );
 
-    let mut attrs = HashMap::new();
+    let mut attrs = FxHashMap::default();
     attrs.insert("axis".to_string(), OnnxAttribute::Int(0));
     node_prefix.push(OnnxNode {
         op_type: "DequantizeLinear".to_string(),
@@ -432,8 +433,8 @@ fn scalar_tensor(value: f32, ctx: &str) -> Result<Tensor, OnnxError> {
 fn rewrite_conv_node_to_qlinear(
     model: &OnnxModel,
     node: &OnnxNode,
-    activation_stats: &HashMap<String, MinMax>,
-    new_initializers: &mut HashMap<String, Tensor>,
+    activation_stats: &FxHashMap<String, MinMax>,
+    new_initializers: &mut FxHashMap<String, Tensor>,
 ) -> Result<Option<Vec<OnnxNode>>, OnnxError> {
     if node.inputs.len() < 2 || node.outputs.len() != 1 {
         return Ok(None);
@@ -533,7 +534,7 @@ fn rewrite_conv_node_to_qlinear(
         name: format!("{}__qlinear_x_quant", node.name),
         inputs: vec![x_name.clone(), x_scale, x_zp],
         outputs: vec![x_q_nhwc.clone()],
-        attributes: HashMap::new(),
+        attributes: FxHashMap::default(),
     });
     if needs_io_transpose {
         out.push(OnnxNode {
@@ -541,7 +542,7 @@ fn rewrite_conv_node_to_qlinear(
             name: format!("{}__qlinear_x_nhwc_to_nchw", node.name),
             inputs: vec![x_q_nhwc],
             outputs: vec![x_q.clone()],
-            attributes: HashMap::from([(
+            attributes: FxHashMap::from_iter([(
                 "perm".to_string(),
                 OnnxAttribute::Ints(vec![0, 3, 1, 2]),
             )]),
@@ -564,7 +565,7 @@ fn rewrite_conv_node_to_qlinear(
             } else {
                 fp32_conv_out.clone()
             }],
-            attributes: HashMap::new(),
+            attributes: FxHashMap::default(),
         },
     ]);
     if needs_io_transpose {
@@ -573,7 +574,7 @@ fn rewrite_conv_node_to_qlinear(
             name: format!("{}__qlinear_y_nchw_to_nhwc", node.name),
             inputs: vec![dq_out_nchw],
             outputs: vec![fp32_conv_out.clone()],
-            attributes: HashMap::from([(
+            attributes: FxHashMap::from_iter([(
                 "perm".to_string(),
                 OnnxAttribute::Ints(vec![0, 2, 3, 1]),
             )]),
@@ -585,7 +586,7 @@ fn rewrite_conv_node_to_qlinear(
             name: format!("{}__qlinear_relu", node.name),
             inputs: vec![fp32_conv_out],
             outputs: vec![y_name.clone()],
-            attributes: HashMap::new(),
+            attributes: FxHashMap::default(),
         });
     }
     Ok(Some(out))
@@ -594,8 +595,8 @@ fn rewrite_conv_node_to_qlinear(
 fn rewrite_matmul_node_to_qlinear(
     model: &OnnxModel,
     node: &OnnxNode,
-    activation_stats: &HashMap<String, MinMax>,
-    new_initializers: &mut HashMap<String, Tensor>,
+    activation_stats: &FxHashMap<String, MinMax>,
+    new_initializers: &mut FxHashMap<String, Tensor>,
 ) -> Result<Option<Vec<OnnxNode>>, OnnxError> {
     if node.inputs.len() < 2 || node.outputs.len() != 1 {
         return Ok(None);
@@ -652,7 +653,7 @@ fn rewrite_matmul_node_to_qlinear(
             name: format!("{}__qlinear_a_quant", node.name),
             inputs: vec![a_name.clone(), a_scale.clone(), a_zp.clone()],
             outputs: vec![a_q.clone()],
-            attributes: HashMap::new(),
+            attributes: FxHashMap::default(),
         },
         OnnxNode {
             op_type: "QLinearMatMul".to_string(),
@@ -668,14 +669,14 @@ fn rewrite_matmul_node_to_qlinear(
                 y_zp.clone(),
             ],
             outputs: vec![qmm_out.clone()],
-            attributes: HashMap::new(),
+            attributes: FxHashMap::default(),
         },
         OnnxNode {
             op_type: "DequantizeLinear".to_string(),
             name: format!("{}__qlinear_y_dequant", node.name),
             inputs: vec![qmm_out, y_scale, y_zp],
             outputs: vec![y_name.clone()],
-            attributes: HashMap::new(),
+            attributes: FxHashMap::default(),
         },
     ]))
 }
@@ -844,7 +845,7 @@ mod tests {
     fn build_minimal_model() -> OnnxModel {
         // Single Conv with a 32-element weight and a 4-element bias.
         let weight: Vec<f32> = (0..32).map(|i| (i as f32 - 16.0) * 0.1).collect();
-        let mut initializers = HashMap::new();
+        let mut initializers = FxHashMap::default();
         initializers.insert(
             "w".to_string(),
             Tensor::from_vec(vec![2, 16], weight).unwrap(),
@@ -862,7 +863,7 @@ mod tests {
                 name: "conv0".to_string(),
                 inputs: vec!["x".to_string(), "w".to_string()],
                 outputs: vec!["y".to_string()],
-                attributes: HashMap::new(),
+                attributes: FxHashMap::default(),
             }],
             khwc_weights: Default::default(),
             dw_khwc_weights: Default::default(),
@@ -875,7 +876,7 @@ mod tests {
     #[test]
     fn weight_only_path_when_no_activation_stats() {
         let mut model = build_minimal_model();
-        let stats = HashMap::new();
+        let stats = FxHashMap::default();
         rewrite_to_qdq(&mut model, &stats, &[]).unwrap();
 
         // Quantized weight + scale + zp present.
@@ -910,7 +911,7 @@ mod tests {
     #[test]
     fn activation_qdq_inserted_when_stats_present() {
         let mut model = build_minimal_model();
-        let mut stats = HashMap::new();
+        let mut stats = FxHashMap::default();
         stats.insert(
             "x".to_string(),
             MinMax {
@@ -943,7 +944,7 @@ mod tests {
     #[test]
     fn keep_fp32_pins_named_node_fully_fp32() {
         let mut model = build_minimal_model();
-        let mut stats = HashMap::new();
+        let mut stats = FxHashMap::default();
         stats.insert(
             "x".to_string(),
             MinMax {
@@ -970,7 +971,7 @@ mod tests {
             "w".to_string(),
             Tensor::from_vec(vec![2, 4], vec![0.1; 8]).unwrap(),
         );
-        rewrite_to_qdq(&mut model, &HashMap::new(), &[]).unwrap();
+        rewrite_to_qdq(&mut model, &FxHashMap::default(), &[]).unwrap();
         assert!(!model.initializers.contains_key("w_q"));
         // Conv input #1 still points to the original weight name.
         assert_eq!(model.nodes[0].inputs[1], "w");
@@ -983,7 +984,7 @@ mod tests {
             "w".to_string(),
             Tensor::from_vec(vec![2, 2, 4, 4], vec![0.05; 64]).unwrap(),
         );
-        let mut stats = HashMap::new();
+        let mut stats = FxHashMap::default();
         stats.insert(
             "x".to_string(),
             MinMax {
@@ -1017,7 +1018,7 @@ mod tests {
             "w".to_string(),
             Tensor::from_vec(vec![1, 1, 16, 2], vec![0.05; 32]).unwrap(),
         );
-        let mut stats = HashMap::new();
+        let mut stats = FxHashMap::default();
         stats.insert(
             "x".to_string(),
             MinMax {
@@ -1058,17 +1059,17 @@ mod tests {
                 name: "conv0".to_string(),
                 inputs: vec!["x".to_string(), "w".to_string()],
                 outputs: vec!["y0".to_string()],
-                attributes: HashMap::new(),
+                attributes: FxHashMap::default(),
             },
             OnnxNode {
                 op_type: "Conv".to_string(),
                 name: "conv1".to_string(),
                 inputs: vec!["x".to_string(), "w1".to_string()],
                 outputs: vec!["y1".to_string()],
-                attributes: HashMap::new(),
+                attributes: FxHashMap::default(),
             },
         ];
-        let mut stats = HashMap::new();
+        let mut stats = FxHashMap::default();
         for name in ["x", "y0", "y1"] {
             stats.insert(
                 name.to_string(),
@@ -1082,7 +1083,7 @@ mod tests {
 
         rewrite_to_qlinear(&mut model, &stats).unwrap();
 
-        let mut outputs = HashSet::new();
+        let mut outputs = FxHashSet::default();
         for node in &model.nodes {
             for out in &node.outputs {
                 assert!(outputs.insert(out.clone()), "duplicate output name `{out}`");
@@ -1114,7 +1115,7 @@ mod tests {
             .attributes
             .insert("group".to_string(), OnnxAttribute::Int(2));
 
-        rewrite_to_qdq(&mut model, &HashMap::new(), &[]).unwrap();
+        rewrite_to_qdq(&mut model, &FxHashMap::default(), &[]).unwrap();
 
         assert_eq!(
             model
@@ -1141,7 +1142,7 @@ mod tests {
     #[test]
     fn fold_constant_qdq_weight_restores_initializer_input() {
         let mut model = build_minimal_model();
-        rewrite_to_qdq(&mut model, &HashMap::new(), &[]).unwrap();
+        rewrite_to_qdq(&mut model, &FxHashMap::default(), &[]).unwrap();
         assert!(
             model
                 .nodes
@@ -1169,7 +1170,7 @@ mod tests {
     #[test]
     fn prune_unused_initializers_removes_folded_qdq_baggage() {
         let mut model = build_minimal_model();
-        rewrite_to_qdq(&mut model, &HashMap::new(), &[]).unwrap();
+        rewrite_to_qdq(&mut model, &FxHashMap::default(), &[]).unwrap();
         fold_constant_qdq_weights_for_yscv_fast(&mut model).unwrap();
 
         let removed = prune_unused_initializers(&mut model);
@@ -1187,7 +1188,7 @@ mod tests {
         // No quantizable nodes -> no-op.
         let mut model = build_minimal_model();
         model.nodes[0].op_type = "Relu".to_string();
-        rewrite_to_qdq(&mut model, &HashMap::new(), &[]).unwrap();
+        rewrite_to_qdq(&mut model, &FxHashMap::default(), &[]).unwrap();
         // Weight still present, no extra inits.
         assert!(model.initializers.contains_key("w"));
         assert!(!model.initializers.contains_key("w_q"));

--- a/crates/yscv-onnx/src/runner/conv/fused.rs
+++ b/crates/yscv-onnx/src/runner/conv/fused.rs
@@ -11,10 +11,10 @@ use super::*;
 /// Executes DW first, then PW immediately while DW output is hot in L1 cache.
 /// Skips intermediate tensor early-deallocation check to keep it cached.
 /// True-fuse DW → PW by keeping the DW output as a local `Tensor`,
-/// never touching the env HashMap for the intermediate. Chains two
+/// never touching the env FxHashMap for the intermediate. Chains two
 /// `conv_compute_nhwc` calls and only binds the final PW result to env.
 /// Saves one `env.insert` + one `env.get` + one `env.remove` + the
-/// associated HashMap lookups per fused pair vs the previous "call
+/// associated FxHashMap lookups per fused pair vs the previous "call
 /// exec_conv_with_params twice" implementation.
 ///
 /// Also does early cleanup of DW's input refs between DW and PW so
@@ -419,7 +419,7 @@ pub(crate) fn exec_fused_dw_pw(
         dw_has_pad,
     )?;
     // `dw_output` is a local owned `Tensor` — NOT inserted into env.
-    // That's the whole point of true fusion: zero env-HashMap traffic
+    // That's the whole point of true fusion: zero env-FxHashMap traffic
     // for the intermediate.
 
     // Drop borrowed tensors so env can be mutated below.
@@ -490,7 +490,7 @@ pub(crate) fn exec_fused_dw_pw(
 
 /// Mirror of `exec_fused_dw_pw` for the inverted-bottleneck opening:
 /// chains `PW_expand → DW` through a local intermediate `Tensor` so the
-/// PW output never touches the env HashMap. Same early DW-input
+/// PW output never touches the env FxHashMap. Same early DW-input
 /// cleanup (here DW's only input is the PW output, which is owned
 /// locally and dropped after DW compute, so the explicit early-cleanup
 /// loop touches only the PW's inputs to free the original activation
@@ -948,14 +948,14 @@ fn try_fused_pw_dw_pw_reduce_nchwc(
     pw_reduce_activation: yscv_kernels::Activation,
     leave_nchwc: bool,
 ) -> Option<Tensor> {
+    use rustc_hash::FxHashMap;
     use std::cell::RefCell;
-    use std::collections::HashMap;
     use std::sync::Arc;
     // Lazy NCHWc DW-weight pack, cached by weight pointer (packed once, reused
     // across all inferences — the bench timing loop never re-packs).
     thread_local! {
-        static DW_PACK: RefCell<HashMap<usize, Arc<yscv_kernels::PackedNChwBc>>> =
-            RefCell::new(HashMap::new());
+        static DW_PACK: RefCell<FxHashMap<usize, Arc<yscv_kernels::PackedNChwBc>>> =
+            RefCell::new(FxHashMap::default());
     }
     let cfg = yscv_kernels::ParallelElementwiseConfig::default();
     let reduce_w = env.get(&pw_reduce_node.inputs[1])?.clone();
@@ -1078,12 +1078,12 @@ fn try_fused_pw_dw_nchwc(
     dw_activation: yscv_kernels::Activation,
     leave_nchwc: bool,
 ) -> Option<Tensor> {
+    use rustc_hash::FxHashMap;
     use std::cell::RefCell;
-    use std::collections::HashMap;
     use std::sync::Arc;
     thread_local! {
-        static DW_PACK: RefCell<HashMap<usize, Arc<yscv_kernels::PackedNChwBc>>> =
-            RefCell::new(HashMap::new());
+        static DW_PACK: RefCell<FxHashMap<usize, Arc<yscv_kernels::PackedNChwBc>>> =
+            RefCell::new(FxHashMap::default());
     }
     let cfg = yscv_kernels::ParallelElementwiseConfig::default();
     let dw_key = dw_weight_tensor.data().as_ptr() as usize;
@@ -1465,12 +1465,12 @@ pub(crate) fn exec_fused_pw_dw_pw_reduce(
             #[cfg(target_arch = "x86_64")]
             {
                 // Lazy DW-weight pack into NCHWc-blocked layout.
+                use rustc_hash::FxHashMap;
                 use std::cell::RefCell;
-                use std::collections::HashMap;
                 use std::sync::Arc;
                 thread_local! {
-                    static DW_BLOCK_PACK: RefCell<HashMap<usize, Arc<Vec<f32>>>> =
-                        RefCell::new(HashMap::new());
+                    static DW_BLOCK_PACK: RefCell<FxHashMap<usize, Arc<Vec<f32>>>> =
+                        RefCell::new(FxHashMap::default());
                 }
                 let dw_key = dw_weight_tensor.data().as_ptr() as usize;
                 let dw_packed = DW_BLOCK_PACK.with(|c| {

--- a/crates/yscv-onnx/src/runner/conv/mod.rs
+++ b/crates/yscv-onnx/src/runner/conv/mod.rs
@@ -302,7 +302,7 @@ pub(super) fn exec_conv(
 }
 
 /// Resolves `(stride, group, pads, has_padding)` from either precomputed
-/// `ConvParams` or the ONNX attribute HashMap. Shared between the thin
+/// `ConvParams` or the ONNX attribute FxHashMap. Shared between the thin
 /// env-binding wrapper `exec_conv_with_params` and the fused-pair path
 /// `exec_fused_dw_pw`.
 #[inline]
@@ -337,14 +337,14 @@ fn resolve_conv_params(
     }
 }
 
-/// Conv with optional pre-computed params (skips HashMap attr lookups).
+/// Conv with optional pre-computed params (skips FxHashMap attr lookups).
 ///
 /// Thin wrapper around [`conv_compute_nhwc`]: resolves input/weight/bias
 /// from `env`, converts input to NHWC if needed, calls the pure-compute
 /// path, then binds the result back into `env`. The split lets the
 /// DW+PW fused path (`exec_fused_dw_pw`) chain two conv computes with
 /// the DW intermediate kept as a local `Tensor` — never touching the
-/// env HashMap.
+/// env FxHashMap.
 pub(super) fn exec_conv_with_params(
     node: &OnnxNode,
     env: &mut TensorEnv,

--- a/crates/yscv-onnx/src/runner/execute.rs
+++ b/crates/yscv-onnx/src/runner/execute.rs
@@ -1,6 +1,8 @@
 //! Top-level inference drivers: the JIT (timed-loop) and sequential
 //! single-pass executors that walk the optimized plan via execute_plan_branch.
 
+use rustc_hash::{FxBuildHasher, FxHashMap};
+
 use super::*;
 
 /// JIT execution path: pre-compiled dispatch table, no per-node matching.
@@ -8,7 +10,7 @@ use super::*;
 pub(crate) fn run_onnx_model_jit(
     model: &OnnxModel,
     mut env: TensorEnv<'_, '_>,
-) -> Result<HashMap<String, Tensor>, OnnxError> {
+) -> Result<FxHashMap<String, Tensor>, OnnxError> {
     let branches = &model.runtime_index.node_branches;
     let use_counts_by_id = &model.runtime_index.use_counts_by_id;
     let output_id_mask = build_output_id_mask(model, &env, use_counts_by_id.len());
@@ -165,7 +167,7 @@ pub(crate) fn run_onnx_model_jit(
         env.materialize_quant_i8_raw(name)?;
         ensure_nchw(&mut env, name)?;
     }
-    let mut result = HashMap::with_capacity(model.outputs.len());
+    let mut result = FxHashMap::with_capacity_and_hasher(model.outputs.len(), FxBuildHasher);
     for name in &model.outputs {
         if let Some(t) = env.remove(name) {
             result.insert(name.clone(), t);
@@ -179,7 +181,7 @@ pub(crate) fn run_onnx_model_jit(
 pub(crate) fn run_onnx_model_sequential(
     model: &OnnxModel,
     mut env: TensorEnv<'_, '_>,
-) -> Result<HashMap<String, Tensor>, OnnxError> {
+) -> Result<FxHashMap<String, Tensor>, OnnxError> {
     // --- Operator fusion: scan for fusible patterns ---
     // Build a set of node indices that should be skipped because they were
     // fused into the preceding node.  We also create synthetic "fused" nodes
@@ -597,7 +599,7 @@ pub(crate) fn run_onnx_model_sequential(
             continue;
         }
 
-        // Fast path for Conv: use pre-computed params to skip attr HashMap lookups
+        // Fast path for Conv: use pre-computed params to skip attr FxHashMap lookups
         if matches!(
             kind,
             NodeKind::Conv | NodeKind::ConvRelu | NodeKind::ConvSilu
@@ -716,7 +718,7 @@ pub(crate) fn run_onnx_model_sequential(
             if inp.is_empty() {
                 continue;
             }
-            // Use pre-resolved ID (O(1)) when available, fallback to HashMap.
+            // Use pre-resolved ID (O(1)) when available, fallback to FxHashMap.
             let id = pre_ids
                 .get(inp_idx)
                 .and_then(|opt| *opt)
@@ -766,7 +768,7 @@ pub(crate) fn run_onnx_model_sequential(
         ensure_nchw(&mut env, name)?;
     }
 
-    let mut result = HashMap::with_capacity(model.outputs.len());
+    let mut result = FxHashMap::with_capacity_and_hasher(model.outputs.len(), FxBuildHasher);
     for name in &model.outputs {
         if let Some(t) = env.remove(name) {
             result.insert(name.clone(), t);

--- a/crates/yscv-onnx/src/runner/gpu/f16.rs
+++ b/crates/yscv-onnx/src/runner/gpu/f16.rs
@@ -804,8 +804,8 @@ pub fn compile_gpu_plan_f16(
     }
 
     // Separate weight cache entries from activation entries
-    let mut weights = GpuCache::new();
-    let mut pinned = GpuCache::new();
+    let mut weights = GpuCache::default();
+    let mut pinned = GpuCache::default();
     let keys: Vec<String> = gc.keys().cloned().collect();
     for k in keys {
         if let Some(v) = gc.remove(&k) {
@@ -833,7 +833,7 @@ pub fn run_compiled_gpu_f16_fused(
     gpu: &GpuBackend,
     compiled: &CompiledGpuPlan,
     input_data: &[f32],
-) -> Result<HashMap<String, Tensor>, OnnxError> {
+) -> Result<FxHashMap<String, Tensor>, OnnxError> {
     // Write input data as f16
     gpu.write_buffer_f16(compiled.input_buf.raw_buffer(), input_data);
 
@@ -841,7 +841,7 @@ pub fn run_compiled_gpu_f16_fused(
     gpu.replay_recording_fused(&compiled.ops);
 
     // Download outputs — handle f16 and f32 buffers based on f16_io flag
-    let mut result = HashMap::new();
+    let mut result = FxHashMap::default();
     for (i, name) in compiled.output_names.iter().enumerate() {
         if let Some((out_buf, nhwc, f16_io)) = compiled.output_bufs.get(i) {
             let shape = out_buf.shape();

--- a/crates/yscv-onnx/src/runner/gpu/mod.rs
+++ b/crates/yscv-onnx/src/runner/gpu/mod.rs
@@ -24,7 +24,7 @@ struct GpuTensor {
 }
 
 /// GPU tensor cache — maps tensor names to device-resident buffers.
-type GpuCache = HashMap<String, GpuTensor>;
+type GpuCache = FxHashMap<String, GpuTensor>;
 
 /// Opaque weight cache that persists transformed weights on GPU across
 /// inference runs. Create with `GpuWeightCache::new()` and pass to
@@ -32,7 +32,7 @@ type GpuCache = HashMap<String, GpuTensor>;
 pub struct GpuWeightCache(GpuCache);
 impl GpuWeightCache {
     pub fn new() -> Self {
-        Self(HashMap::new())
+        Self(FxHashMap::default())
     }
 }
 
@@ -96,7 +96,7 @@ pub enum GpuExecAction {
 pub struct GpuExecPlan {
     /// For each tensor name, the last node index that consumes it.
     /// Model outputs are mapped to `usize::MAX` so they are never recycled.
-    pub last_use: HashMap<String, usize>,
+    pub last_use: FxHashMap<String, usize>,
     /// Precomputed action for every node index.
     pub actions: Vec<GpuExecAction>,
     /// Precomputed per-node recycle lists: `recycle_at[i]` = tensor names to
@@ -112,7 +112,7 @@ pub fn plan_gpu_execution(model: &OnnxModel) -> GpuExecPlan {
     let nodes = &model.nodes;
 
     // ── Precompute tensor last-use index ────────────────────────────
-    let mut last_use: HashMap<String, usize> = HashMap::new();
+    let mut last_use: FxHashMap<String, usize> = FxHashMap::default();
     for (i, node) in nodes.iter().enumerate() {
         for inp in &node.inputs {
             if !inp.is_empty() {
@@ -298,8 +298,8 @@ pub fn plan_gpu_execution(model: &OnnxModel) -> GpuExecPlan {
     // ── Diagnostic: print action breakdown ─────────────────────────
     #[cfg(feature = "profile")]
     {
-        let mut op_counts: HashMap<String, u32> = HashMap::new();
-        let mut fusion_counts: HashMap<&str, u32> = HashMap::new();
+        let mut op_counts: FxHashMap<String, u32> = FxHashMap::default();
+        let mut fusion_counts: FxHashMap<&str, u32> = FxHashMap::default();
         for (i, action) in actions.iter().enumerate() {
             match action {
                 GpuExecAction::Skip => {}
@@ -384,8 +384,8 @@ fn gc_insert(gpu: &GpuBackend, gc: &mut GpuCache, name: String, gt: GpuTensor) {
 /// eliminating the per-op device sync that dominates naive GPU dispatch.
 pub fn run_onnx_model_gpu(
     model: &OnnxModel,
-    inputs: HashMap<String, Tensor>,
-) -> Result<HashMap<String, Tensor>, OnnxError> {
+    inputs: FxHashMap<String, Tensor>,
+) -> Result<FxHashMap<String, Tensor>, OnnxError> {
     let gpu = GpuBackend::new().map_err(|e| OnnxError::DecodeFailed {
         message: format!("GPU init: {e}"),
     })?;
@@ -398,8 +398,8 @@ pub fn run_onnx_model_gpu(
 pub fn run_onnx_model_gpu_with(
     gpu: &GpuBackend,
     model: &OnnxModel,
-    inputs: HashMap<String, Tensor>,
-) -> Result<HashMap<String, Tensor>, OnnxError> {
+    inputs: FxHashMap<String, Tensor>,
+) -> Result<FxHashMap<String, Tensor>, OnnxError> {
     run_onnx_model_gpu_cached(gpu, model, inputs, &mut GpuWeightCache::new(), None)
 }
 
@@ -413,10 +413,10 @@ pub fn run_onnx_model_gpu_with(
 pub fn run_onnx_model_gpu_cached(
     gpu: &GpuBackend,
     model: &OnnxModel,
-    inputs: HashMap<String, Tensor>,
+    inputs: FxHashMap<String, Tensor>,
     weight_cache: &mut GpuWeightCache,
     plan: Option<&GpuExecPlan>,
-) -> Result<HashMap<String, Tensor>, OnnxError> {
+) -> Result<FxHashMap<String, Tensor>, OnnxError> {
     // If no plan was provided, compute one on the fly (original behavior).
     let owned_plan;
     let plan = match plan {
@@ -617,7 +617,7 @@ pub fn run_onnx_model_gpu_cached(
     }
 
     // ── Collect outputs ──────────────────────────────────────────
-    let mut result = HashMap::new();
+    let mut result = FxHashMap::default();
     for name in &model.outputs {
         to_cpu(gpu, name, &mut env, &mut gc)?;
         if let Some(t) = env.get(name) {
@@ -916,8 +916,8 @@ pub fn compile_gpu_plan(
     }
 
     // Separate weight cache entries from activation entries
-    let mut weights = GpuCache::new();
-    let mut pinned = GpuCache::new();
+    let mut weights = GpuCache::default();
+    let mut pinned = GpuCache::default();
     let keys: Vec<String> = gc.keys().cloned().collect();
     for k in keys {
         if let Some(v) = gc.remove(&k) {
@@ -946,7 +946,7 @@ pub fn run_compiled_gpu(
     gpu: &GpuBackend,
     compiled: &CompiledGpuPlan,
     input_data: &[f32],
-) -> Result<HashMap<String, Tensor>, OnnxError> {
+) -> Result<FxHashMap<String, Tensor>, OnnxError> {
     // Write new input data to the pre-allocated input buffer
     gpu.write_buffer(compiled.input_buf.raw_buffer(), input_data);
 
@@ -957,7 +957,7 @@ pub fn run_compiled_gpu(
     gpu.flush();
 
     // Download outputs
-    let mut result = HashMap::new();
+    let mut result = FxHashMap::default();
     for (i, name) in compiled.output_names.iter().enumerate() {
         if let Some((out_buf, nhwc, _f16_io)) = compiled.output_bufs.get(i) {
             let t = gpu.download(out_buf)?;
@@ -1000,7 +1000,7 @@ pub fn run_compiled_gpu_fused(
     gpu: &GpuBackend,
     compiled: &CompiledGpuPlan,
     input_data: &[f32],
-) -> Result<HashMap<String, Tensor>, OnnxError> {
+) -> Result<FxHashMap<String, Tensor>, OnnxError> {
     // Write new input data to the pre-allocated input buffer
     gpu.write_buffer(compiled.input_buf.raw_buffer(), input_data);
 
@@ -1008,7 +1008,7 @@ pub fn run_compiled_gpu_fused(
     gpu.replay_recording_fused(&compiled.ops);
 
     // Download outputs
-    let mut result = HashMap::new();
+    let mut result = FxHashMap::default();
     for (i, name) in compiled.output_names.iter().enumerate() {
         if let Some((out_buf, nhwc, _f16_io)) = compiled.output_bufs.get(i) {
             let t = gpu.download(out_buf)?;
@@ -1044,7 +1044,7 @@ pub fn run_compiled_gpu_fused_timed(
     gpu: &GpuBackend,
     compiled: &CompiledGpuPlan,
     input_data: &[f32],
-) -> Result<(HashMap<String, Tensor>, f64, f64, f64, f64), OnnxError> {
+) -> Result<(FxHashMap<String, Tensor>, f64, f64, f64, f64), OnnxError> {
     let t0 = std::time::Instant::now();
     gpu.write_buffer(compiled.input_buf.raw_buffer(), input_data);
     let t1 = std::time::Instant::now();
@@ -1057,7 +1057,7 @@ pub fn run_compiled_gpu_fused_timed(
     let t3 = std::time::Instant::now();
 
     // Download outputs
-    let mut result = HashMap::new();
+    let mut result = FxHashMap::default();
     for (i, name) in compiled.output_names.iter().enumerate() {
         if let Some((out_buf, nhwc, _f16_io)) = compiled.output_bufs.get(i) {
             let t = gpu.download(out_buf)?;
@@ -1247,8 +1247,8 @@ fn dispatch(
 /// Returns map of action_label → (total_ms, count).
 pub fn profile_onnx_model_gpu(
     model: &OnnxModel,
-    inputs: HashMap<String, Tensor>,
-) -> Result<HashMap<String, (f64, usize)>, OnnxError> {
+    inputs: FxHashMap<String, Tensor>,
+) -> Result<FxHashMap<String, (f64, usize)>, OnnxError> {
     let gpu = GpuBackend::new().map_err(|e| OnnxError::DecodeFailed {
         message: format!("GPU init: {e}"),
     })?;
@@ -1257,7 +1257,7 @@ pub fn profile_onnx_model_gpu(
 
     // Warm-up run to populate weight cache
     {
-        let mut inputs_warm = HashMap::new();
+        let mut inputs_warm = FxHashMap::default();
         for (k, v) in &inputs {
             inputs_warm.insert(k.clone(), v.clone());
         }
@@ -1267,7 +1267,7 @@ pub fn profile_onnx_model_gpu(
     // Now profile with cached weights
     let mut env = TensorEnv::from_model(model);
     let mut gc: GpuCache = std::mem::take(&mut wc.0);
-    let mut stats: HashMap<String, (f64, usize)> = HashMap::new();
+    let mut stats: FxHashMap<String, (f64, usize)> = FxHashMap::default();
 
     for (name, tensor) in &model.initializers {
         env.insert(name.clone(), tensor.clone());

--- a/crates/yscv-onnx/src/runner/layout.rs
+++ b/crates/yscv-onnx/src/runner/layout.rs
@@ -63,7 +63,7 @@ pub(crate) fn reshape_nhwc_passthrough_disabled() -> bool {
 pub(crate) fn try_reshape_nhwc_passthrough(
     node: &OnnxNode,
     env: &mut TensorEnv,
-    use_counts: &HashMap<String, usize>,
+    use_counts: &FxHashMap<String, usize>,
 ) -> Result<bool, OnnxError> {
     if node.inputs.len() < 2 || node.inputs[0].is_empty() {
         return Ok(false);

--- a/crates/yscv-onnx/src/runner/linear.rs
+++ b/crates/yscv-onnx/src/runner/linear.rs
@@ -463,7 +463,7 @@ pub(super) fn exec_qlinear_matmul(node: &OnnxNode, env: &mut TensorEnv) -> Resul
         op_type: "MatMul".to_string(),
         inputs: vec!["__qa".into(), "__qb_mat".into()],
         outputs: vec!["__qmm_out".into()],
-        attributes: HashMap::new(),
+        attributes: FxHashMap::default(),
     };
     env.insert("__qa".into(), deq_a_t);
     env.insert("__qb_mat".into(), deq_b_t);
@@ -667,7 +667,7 @@ pub(super) fn exec_matmul_integer(node: &OnnxNode, env: &mut TensorEnv) -> Resul
         op_type: "MatMul".to_string(),
         inputs: vec!["__mmi_a".into(), "__mmi_b".into()],
         outputs: vec!["__mmi_out".into()],
-        attributes: HashMap::new(),
+        attributes: FxHashMap::default(),
     };
     env.insert("__mmi_a".into(), t_a);
     env.insert("__mmi_b".into(), t_b);

--- a/crates/yscv-onnx/src/runner/metal/compile.rs
+++ b/crates/yscv-onnx/src/runner/metal/compile.rs
@@ -1,5 +1,5 @@
 use ::metal::*;
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::record::{record_conv, record_node};
 use super::types::*;
@@ -34,8 +34,8 @@ pub fn compile_metal_plan(
     // We need tensor shapes AND data for fallback ops. Some ops (Split) consume
     // their inputs, so we snapshot shapes + data for fallback-eligible outputs
     // immediately after each node executes.
-    let mut cpu_shapes: HashMap<String, Vec<usize>> = HashMap::new();
-    let mut cpu_data: HashMap<String, Vec<f32>> = HashMap::new();
+    let mut cpu_shapes: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+    let mut cpu_data: FxHashMap<String, Vec<f32>> = FxHashMap::default();
     for (ni, node) in model.nodes.iter().enumerate() {
         if let Err(e) = execute_node_cpu_for_metal_compile(node, &mut env)
             && debug_metal
@@ -66,12 +66,12 @@ pub fn compile_metal_plan(
     }
 
     // Now we know all tensor shapes. Build Metal buffers and ops.
-    let mut bufs: HashMap<String, Buffer> = HashMap::new();
-    let mut buf_shapes: HashMap<String, Vec<usize>> = HashMap::new();
-    let mut buf_nhwc: HashMap<String, bool> = HashMap::new();
+    let mut bufs: FxHashMap<String, Buffer> = FxHashMap::default();
+    let mut buf_shapes: FxHashMap<String, Vec<usize>> = FxHashMap::default();
+    let mut buf_nhwc: FxHashMap<String, bool> = FxHashMap::default();
     let mut ops = Vec::new();
     // Track buffers that are in f32 format (for attention precision chain)
-    let mut f32_bufs: HashSet<String> = HashSet::new();
+    let mut f32_bufs: FxHashSet<String> = FxHashSet::default();
 
     // Upload input: for 4D NCHW, do f32→f16 + NCHW→NHWC on CPU (avoids GPU cast op).
     let input_shape = input_tensor.shape();
@@ -126,7 +126,7 @@ pub fn compile_metal_plan(
     let nodes = &model.nodes;
 
     // Build a set of node indices to skip (fused into a previous node)
-    let mut skip: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    let mut skip: rustc_hash::FxHashSet<usize> = rustc_hash::FxHashSet::default();
 
     #[cfg(feature = "profile")]
     let debug_metal = std::env::var("METAL_DEBUG").is_ok();
@@ -535,7 +535,7 @@ pub fn compile_metal_plan(
     // the concat copy entirely.
     if std::env::var("METAL_NO_CONV_CONCAT").is_err() {
         // Map conv output name → op index (only for kernels with strided output support)
-        let mut conv_out_idx: HashMap<&str, usize> = HashMap::new();
+        let mut conv_out_idx: FxHashMap<&str, usize> = FxHashMap::default();
         for (i, op) in ops.iter().enumerate() {
             match op {
                 MetalOp::ConvGemm { output, .. }
@@ -548,7 +548,7 @@ pub fn compile_metal_plan(
         }
 
         // Count how many ops read each buffer
-        let mut consumers: HashMap<&str, usize> = HashMap::new();
+        let mut consumers: FxHashMap<&str, usize> = FxHashMap::default();
         for op in &ops {
             let inputs: Vec<&str> = match op {
                 MetalOp::ConvGemm {
@@ -652,7 +652,7 @@ pub fn compile_metal_plan(
         }
 
         // Apply fusions
-        let mut removed_indices: HashSet<usize> = HashSet::new();
+        let mut removed_indices: FxHashSet<usize> = FxHashSet::default();
         for (concat_idx, concat_out, conv_ops, total_c) in &fusions {
             if let Some(concat_buf) = bufs.get(concat_out).cloned() {
                 for &(conv_idx, ch_offset) in conv_ops {
@@ -700,7 +700,8 @@ pub fn compile_metal_plan(
     // Replaces separate NHWC→NCHW permutations + flat copy with a single fused kernel.
     if std::env::var("METAL_NO_FUSION").is_err() {
         // Map CpuReshape output name → (op_idx, nhwc_input_name, (n,h,w,c))
-        let mut reshape_info: HashMap<&str, (usize, &str, (u32, u32, u32, u32))> = HashMap::new();
+        let mut reshape_info: FxHashMap<&str, (usize, &str, (u32, u32, u32, u32))> =
+            FxHashMap::default();
         for (i, op) in ops.iter().enumerate() {
             if let MetalOp::CpuReshape {
                 input,
@@ -714,7 +715,7 @@ pub fn compile_metal_plan(
         }
 
         // Count consumers of each buffer
-        let mut buf_consumers: HashMap<&str, usize> = HashMap::new();
+        let mut buf_consumers: FxHashMap<&str, usize> = FxHashMap::default();
         for op in &ops {
             let ins: Vec<&str> = match op {
                 MetalOp::FlatConcat { inputs, .. } => inputs.iter().map(|s| s.as_str()).collect(),
@@ -750,7 +751,7 @@ pub fn compile_metal_plan(
             }
         }
 
-        let mut removed_indices: HashSet<usize> = HashSet::new();
+        let mut removed_indices: FxHashSet<usize> = FxHashSet::default();
         let mut replacements: Vec<(usize, MetalOp)> = Vec::new();
 
         for (i, op) in ops.iter().enumerate() {
@@ -839,7 +840,7 @@ pub fn compile_metal_plan(
 
         if !removed_indices.is_empty() {
             // Build new ops list: replace FlatConcat with fused op, remove CpuReshape ops
-            let mut repl_map: HashMap<usize, MetalOp> = replacements.into_iter().collect();
+            let mut repl_map: FxHashMap<usize, MetalOp> = replacements.into_iter().collect();
             let old_ops = std::mem::take(&mut ops);
             ops = old_ops
                 .into_iter()
@@ -862,7 +863,7 @@ pub fn compile_metal_plan(
     // This saves both a buffer allocation and a full read+write round-trip.
     if std::env::var("METAL_NO_INPLACE").is_err() {
         // Compute last_use: buffer_name → last op index that reads it
-        let mut last_use: HashMap<String, usize> = HashMap::new();
+        let mut last_use: FxHashMap<String, usize> = FxHashMap::default();
         for (i, op) in ops.iter().enumerate() {
             let inputs: Vec<&str> = match op {
                 MetalOp::ConvGemm {
@@ -969,7 +970,7 @@ pub fn compile_metal_plan(
     let cpu_ref = if std::env::var("METAL_COMPARE").is_ok() {
         cpu_data.clone()
     } else {
-        HashMap::new()
+        FxHashMap::default()
     };
     Ok(MetalPlan {
         inf,
@@ -991,9 +992,9 @@ pub(crate) fn ensure_on_metal(
     inf: &MetalInference,
     name: &str,
     env: &TensorEnv,
-    bufs: &mut HashMap<String, Buffer>,
-    shapes: &mut HashMap<String, Vec<usize>>,
-    nhwc: &mut HashMap<String, bool>,
+    bufs: &mut FxHashMap<String, Buffer>,
+    shapes: &mut FxHashMap<String, Vec<usize>>,
+    nhwc: &mut FxHashMap<String, bool>,
 ) {
     if bufs.contains_key(name) {
         return;
@@ -1019,9 +1020,9 @@ pub(crate) fn ensure_on_metal(
 pub(crate) fn ensure_nhwc_metal(
     inf: &MetalInference,
     name: &str,
-    bufs: &mut HashMap<String, Buffer>,
-    shapes: &mut HashMap<String, Vec<usize>>,
-    nhwc: &mut HashMap<String, bool>,
+    bufs: &mut FxHashMap<String, Buffer>,
+    shapes: &mut FxHashMap<String, Vec<usize>>,
+    nhwc: &mut FxHashMap<String, bool>,
     ops: &mut Vec<MetalOp>,
 ) -> String {
     // Already NHWC natively (e.g. output of a previous Conv)
@@ -1075,11 +1076,11 @@ pub(crate) fn ensure_nhwc_metal(
 pub(crate) fn cpu_fallback(
     node: &OnnxNode,
     env: &TensorEnv,
-    cpu_data: &HashMap<String, Vec<f32>>,
-    cpu_shapes: &HashMap<String, Vec<usize>>,
-    bufs: &mut HashMap<String, Buffer>,
-    shapes: &mut HashMap<String, Vec<usize>>,
-    nhwc: &mut HashMap<String, bool>,
+    cpu_data: &FxHashMap<String, Vec<f32>>,
+    cpu_shapes: &FxHashMap<String, Vec<usize>>,
+    bufs: &mut FxHashMap<String, Buffer>,
+    shapes: &mut FxHashMap<String, Vec<usize>>,
+    nhwc: &mut FxHashMap<String, bool>,
     inf: &MetalInference,
 ) {
     for out_name in &node.outputs {

--- a/crates/yscv-onnx/src/runner/metal/dispatch.rs
+++ b/crates/yscv-onnx/src/runner/metal/dispatch.rs
@@ -1,5 +1,5 @@
 use ::metal::*;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use super::types::*;
 
@@ -118,7 +118,7 @@ pub(crate) fn dispatch_compute_op(
     plan: &MetalPlan,
     enc: &MetalEncoder,
     op: &MetalOp,
-    bufs: &HashMap<String, Buffer>,
+    bufs: &FxHashMap<String, Buffer>,
 ) {
     let gb = |name: &str| -> &Buffer {
         bufs.get(name).unwrap_or_else(|| {

--- a/crates/yscv-onnx/src/runner/metal/graph.rs
+++ b/crates/yscv-onnx/src/runner/metal/graph.rs
@@ -2,8 +2,8 @@
 //! Builds an MPSGraph from the ONNX model, compiles it once,
 //! then executes as a single GPU dispatch — no per-op encoder transitions.
 
+use rustc_hash::{FxHashMap, FxBuildHasher};
 use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
 
 use metal::*;
 
@@ -75,7 +75,7 @@ pub struct MpsGraphPlan {
 /// Opaque handle returned by `submit_mpsgraph_plan`. Identifies which
 /// pipeline slot's buffers hold (or will hold) the result. Pass to
 /// `wait_mpsgraph_plan` to block until the GPU finishes and widen the
-/// outputs into a `HashMap<String, Tensor>`.
+/// outputs into a `FxHashMap<String, Tensor>`.
 #[must_use = "an InferenceHandle represents in-flight GPU work; wait on it or the next submit will back-pressure"]
 pub struct InferenceHandle {
     slot_idx: usize,
@@ -117,8 +117,8 @@ pub fn compile_mpsgraph_plan(
     })?;
     let queue = device.new_command_queue();
 
-    let mut tensors: HashMap<String, MpsGraphTensorRef> = HashMap::new();
-    let mut cpu_shapes: HashMap<String, Vec<usize>> = HashMap::new();
+    let mut tensors: FxHashMap<String, MpsGraphTensorRef> = FxHashMap::default();
+    let mut cpu_shapes: FxHashMap<String, Vec<usize>> = FxHashMap::default();
 
     // One f32 placeholder + f16-cast per user input. These go into the graph
     // once; per-pipeline-slot backing buffers are allocated after compile.
@@ -186,7 +186,7 @@ pub fn compile_mpsgraph_plan(
 
     // Constant values map for compile-time shape ops (Shape, Gather, etc.)
     // These produce integer/metadata tensors that don't go into the GPU graph.
-    let mut const_values: HashMap<String, Vec<f32>> = HashMap::new();
+    let mut const_values: FxHashMap<String, Vec<f32>> = FxHashMap::default();
     // Seed with initializer data
     for (name, tensor) in &model.initializers {
         const_values.insert(name.clone(), tensor.data().to_vec());
@@ -643,7 +643,7 @@ pub fn submit_mpsgraph_plan(
 pub fn wait_mpsgraph_plan(
     plan: &MpsGraphPlan,
     handle: InferenceHandle,
-) -> Result<HashMap<String, Tensor>, OnnxError> {
+) -> Result<FxHashMap<String, Tensor>, OnnxError> {
     let slot = &plan.slots[handle.slot_idx];
 
     // Drain the in-flight command buffer. `take` leaves `None` so a
@@ -654,7 +654,7 @@ pub fn wait_mpsgraph_plan(
     }
 
     // Widen f16 outputs → f32 Tensors.
-    let mut result = HashMap::with_capacity(plan.output_names.len());
+    let mut result = FxHashMap::with_capacity_and_hasher(plan.output_names.len(), FxBuildHasher);
     for (idx, name) in plan.output_names.iter().enumerate() {
         let buf = &slot.output_bufs[idx];
         let shape = &plan.output_shapes[idx];
@@ -684,7 +684,7 @@ pub fn wait_mpsgraph_plan(
 pub fn run_mpsgraph_plan(
     plan: &MpsGraphPlan,
     inputs: &[(&str, &[f32])],
-) -> Result<HashMap<String, Tensor>, OnnxError> {
+) -> Result<FxHashMap<String, Tensor>, OnnxError> {
     let handle = submit_mpsgraph_plan(plan, inputs)?;
     wait_mpsgraph_plan(plan, handle)
 }
@@ -759,10 +759,10 @@ fn f16_bits_to_f32_scalar(bits: u16) -> f32 {
 fn build_graph_node(
     graph: &MpsGraph,
     node: &OnnxNode,
-    tensors: &HashMap<String, MpsGraphTensorRef>,
-    shapes: &HashMap<String, Vec<usize>>,
+    tensors: &FxHashMap<String, MpsGraphTensorRef>,
+    shapes: &FxHashMap<String, Vec<usize>>,
     model: &OnnxModel,
-    const_values: &HashMap<String, Vec<f32>>,
+    const_values: &FxHashMap<String, Vec<f32>>,
 ) -> Result<Option<Vec<(String, MpsGraphTensorRef, Vec<usize>)>>, KernelError> {
     // Helper: return Ok(None) when an input tensor is not found (unsupported path)
     macro_rules! try_get {
@@ -1428,7 +1428,7 @@ fn build_graph_node(
             let mut out_shape = Vec::new();
             let rank = in_shape.len() as i64;
             if let Some(axes) = axes {
-                let ax_set: std::collections::HashSet<usize> = axes
+                let ax_set: rustc_hash::FxHashSet<usize> = axes
                     .iter()
                     .map(|&a| {
                         if a < 0 {

--- a/crates/yscv-onnx/src/runner/metal/record.rs
+++ b/crates/yscv-onnx/src/runner/metal/record.rs
@@ -1,5 +1,6 @@
 use ::metal::*;
-use std::collections::{HashMap, HashSet};
+use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 
 use super::compile::{cpu_fallback, ensure_nhwc_metal, ensure_on_metal};
 use super::types::*;
@@ -24,11 +25,11 @@ fn resolve_attn_input(
     inf: &MetalInference,
     name: &str,
     is_attn: bool,
-    bufs: &mut HashMap<String, Buffer>,
-    shapes: &mut HashMap<String, Vec<usize>>,
-    nhwc_map: &mut HashMap<String, bool>,
+    bufs: &mut FxHashMap<String, Buffer>,
+    shapes: &mut FxHashMap<String, Vec<usize>>,
+    nhwc_map: &mut FxHashMap<String, bool>,
     ops: &mut Vec<MetalOp>,
-    f32_bufs: &mut HashSet<String>,
+    f32_bufs: &mut FxHashSet<String>,
 ) -> String {
     if name.is_empty() || !bufs.contains_key(name) {
         return name.to_string();
@@ -89,9 +90,9 @@ pub(crate) fn record_conv(
     inf: &MetalInference,
     node: &OnnxNode,
     env: &TensorEnv,
-    bufs: &mut HashMap<String, Buffer>,
-    shapes: &mut HashMap<String, Vec<usize>>,
-    nhwc: &mut HashMap<String, bool>,
+    bufs: &mut FxHashMap<String, Buffer>,
+    shapes: &mut FxHashMap<String, Vec<usize>>,
+    nhwc: &mut FxHashMap<String, bool>,
     ops: &mut Vec<MetalOp>,
     act: u32,
 ) -> Result<(), OnnxError> {
@@ -390,13 +391,13 @@ pub(crate) fn record_node(
     inf: &MetalInference,
     node: &OnnxNode,
     env: &TensorEnv,
-    cpu_data: &HashMap<String, Vec<f32>>,
-    cpu_shapes: &HashMap<String, Vec<usize>>,
-    bufs: &mut HashMap<String, Buffer>,
-    shapes: &mut HashMap<String, Vec<usize>>,
-    nhwc: &mut HashMap<String, bool>,
+    cpu_data: &FxHashMap<String, Vec<f32>>,
+    cpu_shapes: &FxHashMap<String, Vec<usize>>,
+    bufs: &mut FxHashMap<String, Buffer>,
+    shapes: &mut FxHashMap<String, Vec<usize>>,
+    nhwc: &mut FxHashMap<String, bool>,
     ops: &mut Vec<MetalOp>,
-    f32_bufs: &mut HashSet<String>,
+    f32_bufs: &mut FxHashSet<String>,
 ) -> Result<(), OnnxError> {
     // Ensure all inputs are available
     for input_name in &node.inputs {
@@ -1102,8 +1103,8 @@ pub(crate) fn record_node(
 
             // Helper: allocate output buffer (f32 if input was f32, f16 otherwise)
             let alloc_out = |inf: &MetalInference,
-                             bufs: &mut HashMap<String, Buffer>,
-                             f32_bufs: &mut HashSet<String>,
+                             bufs: &mut FxHashMap<String, Buffer>,
+                             f32_bufs: &mut FxHashSet<String>,
                              name: &str,
                              n: usize| {
                 if in_is_f32 {

--- a/crates/yscv-onnx/src/runner/metal/run.rs
+++ b/crates/yscv-onnx/src/runner/metal/run.rs
@@ -7,7 +7,7 @@
 
 use ::metal::*;
 use ::objc::rc::autoreleasepool;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use super::dispatch::{dispatch_compute_op, dispatch_with_mps};
 use super::types::*;
@@ -24,7 +24,7 @@ use crate::error::OnnxError;
 pub fn run_metal_plan(
     plan: &MetalPlan,
     input_data: &[f32],
-) -> Result<HashMap<String, Tensor>, OnnxError> {
+) -> Result<FxHashMap<String, Tensor>, OnnxError> {
     let t0 = std::time::Instant::now();
     // Upload input — CPU-side or GPU-side conversion depending on plan
     match &plan.input_upload {
@@ -62,7 +62,7 @@ pub fn run_metal_plan(
         .any(|op| matches!(op, MetalOp::MpsConv { .. }));
 
     // Encode all ops in a single command buffer
-    let result: Result<HashMap<String, Tensor>, KernelError> = autoreleasepool(|| {
+    let result: Result<FxHashMap<String, Tensor>, KernelError> = autoreleasepool(|| {
         let cmd = plan.inf.queue.new_command_buffer();
 
         if has_mps {
@@ -1009,8 +1009,8 @@ pub fn run_metal_plan(
                 }
             };
             // Measure per-op by encoding each in its own command buffer
-            let mut type_times: std::collections::HashMap<&str, (f64, usize)> =
-                std::collections::HashMap::new();
+            let mut type_times: rustc_hash::FxHashMap<&str, (f64, usize)> =
+                rustc_hash::FxHashMap::default();
             let mut individual_ops: Vec<(String, f64)> = Vec::new();
             for (idx, op) in plan.ops.iter().enumerate() {
                 let pcmd = plan.inf.queue.new_command_buffer();
@@ -1593,7 +1593,7 @@ pub fn run_metal_plan(
         }
 
         // Download outputs inside autoreleasepool (read from _f32out buffers cast from f16)
-        let mut result = HashMap::new();
+        let mut result = FxHashMap::default();
         #[cfg(feature = "profile")]
         let debug_dl = std::env::var("METAL_DEBUG_DL").is_ok();
         #[cfg(not(feature = "profile"))]

--- a/crates/yscv-onnx/src/runner/metal/types.rs
+++ b/crates/yscv-onnx/src/runner/metal/types.rs
@@ -1,5 +1,5 @@
 use ::metal::*;
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use yscv_kernels::metal_backend::metal_conv::{ConvParams, MetalInference, WinogradParams};
 
@@ -21,18 +21,18 @@ pub struct MetalPlan {
     pub(crate) inf: MetalInference,
     pub(crate) ops: Vec<MetalOp>,
     /// All named buffers (weights + intermediates).
-    pub(crate) bufs: HashMap<String, Buffer>,
-    pub(crate) buf_shapes: HashMap<String, Vec<usize>>,
-    pub(crate) buf_nhwc: HashMap<String, bool>,
+    pub(crate) bufs: FxHashMap<String, Buffer>,
+    pub(crate) buf_shapes: FxHashMap<String, Vec<usize>>,
+    pub(crate) buf_nhwc: FxHashMap<String, bool>,
     pub(crate) input_buf_name: String,
     pub(crate) input_upload: InputUploadMode,
     pub(crate) output_names: Vec<String>,
     /// Debug: CPU reference data for per-buffer comparison (only when METAL_COMPARE is set)
     #[allow(dead_code)]
-    pub(crate) cpu_ref: HashMap<String, Vec<f32>>,
+    pub(crate) cpu_ref: FxHashMap<String, Vec<f32>>,
     /// Buffers that hold f32 data (for attention chain)
     #[cfg_attr(not(feature = "profile"), allow(dead_code))]
-    pub(crate) buf_f32: HashSet<String>,
+    pub(crate) buf_f32: FxHashSet<String>,
 }
 
 #[allow(dead_code)]
@@ -282,7 +282,7 @@ impl MetalPlan {
     /// Print op distribution and key dimensions for diagnostics.
     #[cfg(feature = "profile")]
     pub fn dump_op_stats(&self) {
-        let mut counts: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+        let mut counts: rustc_hash::FxHashMap<&str, usize> = rustc_hash::FxHashMap::default();
         for op in &self.ops {
             let name = match op {
                 MetalOp::ConvGemm { .. } => "ConvGemm",

--- a/crates/yscv-onnx/src/runner/mod.rs
+++ b/crates/yscv-onnx/src/runner/mod.rs
@@ -1,4 +1,5 @@
-pub(crate) use std::collections::{HashMap, HashSet};
+use rustc_hash::FxHashMap;
+pub(crate) use rustc_hash::FxHashSet;
 
 pub(crate) use yscv_kernels::{
     BatchNorm2dParams, add as kernel_add, avg_pool2d_nhwc, batch_norm2d_nhwc, matmul_2d,
@@ -233,16 +234,16 @@ impl<'m> OnnxRunner<'m> {
     }
 
     /// Run inference with borrowed input pairs (zero-copy).
-    pub fn run(&self, inputs: &[(&str, &Tensor)]) -> Result<HashMap<String, Tensor>, OnnxError> {
+    pub fn run(&self, inputs: &[(&str, &Tensor)]) -> Result<FxHashMap<String, Tensor>, OnnxError> {
         let env = TensorEnv::from_model_with_inputs(self.model, Some(RuntimeInputs::Slice(inputs)));
         self.run_with_env(env)
     }
 
-    /// Run inference with owned inputs HashMap.
+    /// Run inference with owned inputs FxHashMap.
     pub fn run_owned(
         &self,
-        inputs: HashMap<String, Tensor>,
-    ) -> Result<HashMap<String, Tensor>, OnnxError> {
+        inputs: FxHashMap<String, Tensor>,
+    ) -> Result<FxHashMap<String, Tensor>, OnnxError> {
         let mut env = TensorEnv::from_model(self.model);
         for (name, tensor) in inputs {
             env.insert(name, tensor);
@@ -250,7 +251,7 @@ impl<'m> OnnxRunner<'m> {
         self.run_with_env(env)
     }
 
-    fn run_with_env(&self, env: TensorEnv<'_, '_>) -> Result<HashMap<String, Tensor>, OnnxError> {
+    fn run_with_env(&self, env: TensorEnv<'_, '_>) -> Result<FxHashMap<String, Tensor>, OnnxError> {
         // Install the active ParallelScope on the inference thread so
         // migrated kernel sites (see `yscv_kernels::with_scope`) pick it
         // up without a signature-threading refactor. Dropped
@@ -343,8 +344,8 @@ impl<'m> OnnxRunner<'m> {
 /// Returns a map of output-name -> tensor for the graph's declared outputs.
 pub fn run_onnx_model(
     model: &OnnxModel,
-    inputs: HashMap<String, Tensor>,
-) -> Result<HashMap<String, Tensor>, OnnxError> {
+    inputs: FxHashMap<String, Tensor>,
+) -> Result<FxHashMap<String, Tensor>, OnnxError> {
     let mut env = TensorEnv::from_model(model);
 
     // Initializers (weights) are accessed via zero-copy fallback reference
@@ -362,21 +363,21 @@ pub fn run_onnx_model(
 /// runtime performs clone-on-write into environment slots.
 pub fn run_onnx_model_borrowed(
     model: &OnnxModel,
-    inputs: &HashMap<String, Tensor>,
-) -> Result<HashMap<String, Tensor>, OnnxError> {
+    inputs: &FxHashMap<String, Tensor>,
+) -> Result<FxHashMap<String, Tensor>, OnnxError> {
     let env = TensorEnv::from_model_with_inputs(model, Some(RuntimeInputs::Map(inputs)));
     run_onnx_model_inner(model, env)
 }
 
 /// Runs inference with borrowed input pairs (`name`, `tensor_ref`) without
-/// requiring a `HashMap` allocation at the call site.
+/// requiring a `FxHashMap` allocation at the call site.
 ///
 /// This is zero-copy at the API boundary. Runtime treats inputs as read-only and
 /// clones on write only when mutation is required internally.
 pub fn run_onnx_model_borrowed_slice(
     model: &OnnxModel,
     inputs: &[(&str, &Tensor)],
-) -> Result<HashMap<String, Tensor>, OnnxError> {
+) -> Result<FxHashMap<String, Tensor>, OnnxError> {
     let env = TensorEnv::from_model_with_inputs(model, Some(RuntimeInputs::Slice(inputs)));
     run_onnx_model_inner(model, env)
 }
@@ -385,7 +386,7 @@ pub fn run_onnx_model_borrowed_slice(
 fn tensor_use_count(
     env: &TensorEnv<'_, '_>,
     use_counts_by_id: &[usize],
-    fallback_use_counts: &HashMap<String, usize>,
+    fallback_use_counts: &FxHashMap<String, usize>,
     name: &str,
 ) -> usize {
     env.resolve_id(name)
@@ -435,7 +436,7 @@ fn mark_skip_indices(skip: &mut [bool], indices: &[usize]) {
 fn run_onnx_model_inner(
     model: &OnnxModel,
     env: TensorEnv<'_, '_>,
-) -> Result<HashMap<String, Tensor>, OnnxError> {
+) -> Result<FxHashMap<String, Tensor>, OnnxError> {
     // Use JIT execution plan if available (pre-compiled dispatch, no per-node matching)
     if !model.runtime_index.execution_plan.is_empty() {
         return run_onnx_model_jit(model, env);

--- a/crates/yscv-onnx/src/runner/plan_branch.rs
+++ b/crates/yscv-onnx/src/runner/plan_branch.rs
@@ -648,7 +648,7 @@ pub(crate) fn execute_plan_branch(
 
                 if let Some(fused_out) = fused_result {
                     let add_out = &add_node.outputs[0];
-                    // cached add_out slot ID avoids a HashMap
+                    // cached add_out slot ID avoids a FxHashMap
                     // lookup inside insert + mark_nhwc. On tracker this fires
                     // 24× per inference (one per residual block).
                     let add_out_id = model

--- a/crates/yscv-onnx/src/runner/profile.rs
+++ b/crates/yscv-onnx/src/runner/profile.rs
@@ -23,7 +23,7 @@ use super::*;
 /// would otherwise contend on a shared lock inside per-op timing.
 #[derive(Default)]
 struct RunnerProfileStore {
-    per_node: HashMap<String, RunnerNodeStat>,
+    per_node: FxHashMap<String, RunnerNodeStat>,
 }
 
 #[derive(Clone, Default)]
@@ -142,7 +142,7 @@ pub fn dump_runner_profile(path: &str) -> Result<(), OnnxError> {
             .map_err(|e| OnnxError::DecodeFailed {
                 message: format!("runner profile registry poisoned: {e}"),
             })?;
-        let mut merged: HashMap<String, RunnerNodeStat> = HashMap::new();
+        let mut merged: FxHashMap<String, RunnerNodeStat> = FxHashMap::default();
         for thread_store in registry.iter() {
             let store = thread_store.lock().map_err(|e| OnnxError::DecodeFailed {
                 message: format!("runner profile per-thread mutex poisoned: {e}"),
@@ -356,7 +356,7 @@ impl ProfileFilter {
 /// unfiltered JSON.
 pub fn profile_onnx_model_cpu(
     model: &OnnxModel,
-    inputs: HashMap<String, Tensor>,
+    inputs: FxHashMap<String, Tensor>,
 ) -> Result<(), OnnxError> {
     use std::time::Instant;
 
@@ -368,7 +368,7 @@ pub fn profile_onnx_model_cpu(
     let nodes = &model.nodes;
     let node_kinds = &model.runtime_index.node_kinds;
     let mut skip = vec![false; nodes.len()];
-    let mut timings: HashMap<String, (f64, usize)> = HashMap::new();
+    let mut timings: FxHashMap<String, (f64, usize)> = FxHashMap::default();
     let filter = ProfileFilter::from_env();
     // Per-instance timings — feed the detail table and `YSCV_PROFILE_JSON`.
     let mut instance_timings: Vec<NodeTiming> = Vec::with_capacity(nodes.len());

--- a/crates/yscv-onnx/src/runner/reshape.rs
+++ b/crates/yscv-onnx/src/runner/reshape.rs
@@ -27,7 +27,7 @@ pub(super) fn exec_reshape(node: &OnnxNode, env: &mut TensorEnv) -> Result<(), O
 pub(super) fn exec_reshape_zerocopy(
     node: &OnnxNode,
     env: &mut TensorEnv,
-    use_counts: &HashMap<String, usize>,
+    use_counts: &FxHashMap<String, usize>,
 ) -> Result<(), OnnxError> {
     exec_reshape_inner(node, env, Some(use_counts))
 }
@@ -35,7 +35,7 @@ pub(super) fn exec_reshape_zerocopy(
 fn exec_reshape_inner(
     node: &OnnxNode,
     env: &mut TensorEnv,
-    use_counts: Option<&HashMap<String, usize>>,
+    use_counts: Option<&FxHashMap<String, usize>>,
 ) -> Result<(), OnnxError> {
     // Compute new_shape without cloning the shape tensor data. We iterate the
     // shape-tensor slice directly inside the borrow scope, then drop the

--- a/crates/yscv-onnx/src/runner/tensor_env.rs
+++ b/crates/yscv-onnx/src/runner/tensor_env.rs
@@ -10,9 +10,9 @@ use super::*;
 /// Model initializers (weights) are referenced without cloning. Only when
 /// mutation is needed (get_mut/remove) is a clone-on-write performed.
 pub(crate) struct TensorEnv<'m, 'i> {
-    static_name_to_id: &'m HashMap<String, usize>,
+    static_name_to_id: &'m FxHashMap<String, usize>,
     pub(crate) use_counts_by_id: &'m [usize],
-    dynamic_name_to_id: HashMap<String, usize>,
+    dynamic_name_to_id: FxHashMap<String, usize>,
     slots: Vec<Option<Tensor>>,
     quant_slots: Vec<Option<QuantTensor>>,
     /// Per-slot flag: true if the tensor is stored in NHWC layout.
@@ -22,45 +22,45 @@ pub(crate) struct TensorEnv<'m, 'i> {
     /// adjacent FusedDwPw_AVX512 ops share NCHWc layout.
     nchwc_block_flags: Vec<u8>,
     /// Slot IDs whose tensors have been pre-permuted from OIHW to KHWC.
-    khwc_weights: &'m HashSet<usize>,
+    khwc_weights: &'m FxHashSet<usize>,
     /// Slot IDs whose depthwise weights were pre-permuted [O,1,KH,KW] → [KH,KW,C,dm].
-    dw_khwc_weights: &'m HashSet<usize>,
+    dw_khwc_weights: &'m FxHashSet<usize>,
     /// Slot IDs whose grouped-conv weights were pre-permuted [O,I/G,KH,KW] → [O,KH,KW,I/G].
-    group_khwc_weights: &'m HashSet<usize>,
+    group_khwc_weights: &'m FxHashSet<usize>,
     /// Pre-packed blocked-GEMM B-matrices keyed by weight tensor name. Built
     /// once at model load (`build_runtime_index`). Hot path looks up by the
     /// Conv/MatMul's weight input name and hands the shared `Arc<PackedB>`
     /// straight into the GEMM layer, skipping fingerprint cache + repack.
-    prepacked_weights: &'m HashMap<String, std::sync::Arc<yscv_kernels::PackedB>>,
+    prepacked_weights: &'m FxHashMap<String, std::sync::Arc<yscv_kernels::PackedB>>,
     /// Symmetric-int8 RHS matrices packed once at model load for
     /// QLinearConv/QLinearMatMul/MatMulInteger fast paths.
-    prepacked_i8_weights: &'m HashMap<String, std::sync::Arc<yscv_kernels::PackedI8B>>,
+    prepacked_i8_weights: &'m FxHashMap<String, std::sync::Arc<yscv_kernels::PackedI8B>>,
     /// QLinear depthwise 3x3/5x5 weights packed once as KHWC i8.
-    prepacked_i8_depthwise: &'m HashMap<String, std::sync::Arc<Vec<i8>>>,
+    prepacked_i8_depthwise: &'m FxHashMap<String, std::sync::Arc<Vec<i8>>>,
     scratch_i8_a: Vec<i8>,
     scratch_i32: Vec<i32>,
     /// Counter for dynamically allocated temporary names that were not in
     /// the pre-built mapping (e.g., "__qa", "__qb_mat").
     next_dynamic: usize,
     /// Reference to model initializers for zero-copy weight access.
-    initializers: &'m HashMap<String, Tensor>,
+    initializers: &'m FxHashMap<String, Tensor>,
     /// Side-table of MatMul/Gemm weights packed as symmetric INT4 with
     /// per-group fp32 scales. Hot-path GEMV dispatch consults this map
     /// before falling back to the fp32 path.
-    pub(crate) packed_int4_weights: &'m HashMap<String, crate::quantize::PackedInt4Weight>,
+    pub(crate) packed_int4_weights: &'m FxHashMap<String, crate::quantize::PackedInt4Weight>,
     /// Shared reference to the loader-computed set of Reshape output tensor
     /// names whose single consumer is a `FusedTransposeMatMul` (perm=[0,2,1]).
     /// Used by
     /// `execute_node_with_layout_kind_inner` to gate the NHWC-passthrough
     /// fast path.
-    pub(crate) reshape_nhwc_passthrough_safe: &'m HashSet<String>,
+    pub(crate) reshape_nhwc_passthrough_safe: &'m FxHashSet<String>,
     /// Optional borrowed runtime inputs for zero-copy inference entry.
     runtime_inputs: Option<RuntimeInputs<'i>>,
 }
 
 #[derive(Clone, Copy)]
 pub(crate) enum RuntimeInputs<'i> {
-    Map(&'i HashMap<String, Tensor>),
+    Map(&'i FxHashMap<String, Tensor>),
     Slice(&'i [(&'i str, &'i Tensor)]),
 }
 
@@ -81,7 +81,7 @@ impl<'m, 'i> TensorEnv<'m, 'i> {
             next_dynamic: num_slots,
             static_name_to_id: &model.runtime_index.name_to_id,
             use_counts_by_id: &model.runtime_index.use_counts_by_id,
-            dynamic_name_to_id: HashMap::new(),
+            dynamic_name_to_id: FxHashMap::default(),
             slots: vec![None; num_slots],
             quant_slots: vec![None; num_slots],
             nhwc_flags: vec![false; num_slots],
@@ -184,7 +184,7 @@ impl<'m, 'i> TensorEnv<'m, 'i> {
             .or_else(|| self.runtime_input(name))
     }
 
-    /// Direct slot removal by pre-resolved ID — O(1), no HashMap lookup.
+    /// Direct slot removal by pre-resolved ID — O(1), no FxHashMap lookup.
     #[inline]
     pub(crate) fn remove_by_id(&mut self, id: usize) {
         if id < self.slots.len() {
@@ -253,7 +253,7 @@ impl<'m, 'i> TensorEnv<'m, 'i> {
     }
 
     /// direct slot insertion by pre-resolved ID, skipping
-    /// the HashMap lookup inside `resolve_id`. Caller (runner hot path)
+    /// the FxHashMap lookup inside `resolve_id`. Caller (runner hot path)
     /// passes the slot ID from `node_output_ids` table. Mirrors
     /// `remove_by_id` for output path.
     #[inline]

--- a/crates/yscv-onnx/src/tests/calibration.rs
+++ b/crates/yscv-onnx/src/tests/calibration.rs
@@ -74,7 +74,7 @@ fn collector_captures_runner_activations() {
     //   relu_out:  min=0,  max=4
     //   output:    min=0,  max=12
     let input = Tensor::from_vec(vec![1, 1, 2, 2], vec![-1.0, 0.0, 1.0, 2.0]).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("calib_test_input_xyz".to_string(), input);
 
     let collector = CalibrationCollector::new();
@@ -159,7 +159,7 @@ fn no_recording_outside_scope() {
     );
     let model = load_onnx_model(&bytes).unwrap();
     let input = Tensor::from_vec(vec![1, 1, 1, 1], vec![1.0_f32]).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("calib_test_input_xyz".to_string(), input);
 
     let collector = CalibrationCollector::new();
@@ -217,7 +217,7 @@ fn rewrite_to_qdq_round_trip_keeps_model_runnable() {
     let input = Tensor::from_vec(vec![1, 4, 2, 2], input_data).unwrap();
 
     // 1) Reference fp32 run.
-    let mut feed_fp32 = HashMap::new();
+    let mut feed_fp32 = FxHashMap::default();
     feed_fp32.insert(input_name.to_string(), input.clone());
     let result_fp32 = run_onnx_model(&model_fp32, feed_fp32).unwrap();
     let y_fp32 = result_fp32[output_name].clone();
@@ -227,7 +227,7 @@ fn rewrite_to_qdq_round_trip_keeps_model_runnable() {
     let collector = CalibrationCollector::new();
     {
         let _scope = collector.scope();
-        let mut feed_cal = HashMap::new();
+        let mut feed_cal = FxHashMap::default();
         feed_cal.insert(input_name.to_string(), input.clone());
         let _ = run_onnx_model(&model_fp32, feed_cal).unwrap();
     }
@@ -258,7 +258,7 @@ fn rewrite_to_qdq_round_trip_keeps_model_runnable() {
     );
 
     // 4) Run rewritten model.
-    let mut feed_qdq = HashMap::new();
+    let mut feed_qdq = FxHashMap::default();
     feed_qdq.insert(input_name.to_string(), input);
     let result_qdq = run_onnx_model(&model_qdq, feed_qdq).unwrap();
     let y_qdq = &result_qdq[output_name];

--- a/crates/yscv-onnx/src/tests/conv_pool.rs
+++ b/crates/yscv-onnx/src/tests/conv_pool.rs
@@ -34,7 +34,7 @@ fn exec_conv_with_padding() {
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
     )
     .unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("x".to_string(), input.clone());
     let result = run_onnx_model(&model, feed).unwrap();
     let output = &result["y"];
@@ -73,7 +73,7 @@ fn dispatch_records_depthwise_padded_kernel() {
     let bytes = build_minimal_onnx_model(vec![node], vec![conv_w], vec!["x", "w"], vec!["y"]);
     let model = load_onnx_model(&bytes).unwrap();
     let input = Tensor::from_vec(vec![1, c, 3, 3], vec![1.0f32; c * 9]).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("x".to_string(), input);
     run_onnx_model(&model, feed).unwrap();
 
@@ -114,7 +114,7 @@ fn dispatch_records_pointwise_gemm_kernel() {
     let bytes = build_minimal_onnx_model(vec![node], vec![conv_w], vec!["x", "w"], vec!["y"]);
     let model = load_onnx_model(&bytes).unwrap();
     let input = Tensor::from_vec(vec![1, i, 2, 2], vec![1.0f32; i * 4]).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("x".to_string(), input);
     run_onnx_model(&model, feed).unwrap();
 
@@ -151,7 +151,7 @@ fn dispatch_records_matmul_kernel() {
     let bytes = build_minimal_onnx_model(vec![node], vec![b_w], vec!["x", "w"], vec!["y"]);
     let model = load_onnx_model(&bytes).unwrap();
     let input = Tensor::from_vec(vec![32, 64], vec![0.1f32; 32 * 64]).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("x".to_string(), input);
     run_onnx_model(&model, feed).unwrap();
 
@@ -204,7 +204,7 @@ fn dispatch_records_gemm_kernel() {
     );
     let model = load_onnx_model(&bytes).unwrap();
     let input = Tensor::from_vec(vec![32, 64], vec![0.1f32; 32 * 64]).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("x".to_string(), input);
     run_onnx_model(&model, feed).unwrap();
 

--- a/crates/yscv-onnx/src/tests/coverage.rs
+++ b/crates/yscv-onnx/src/tests/coverage.rs
@@ -191,7 +191,7 @@ fn quantize_dequantize_round_trip_is_close_to_identity() {
         vec!["y"],
     );
     let model = load_onnx_model(&bytes).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("x".to_string(), input);
     let _ = scale; // explicitly unused: initializer is the source of truth
     let _ = zp;
@@ -223,7 +223,7 @@ fn dynamic_quantize_linear_three_outputs() {
     let bytes =
         build_minimal_onnx_model(vec![node], vec![], vec!["x"], vec!["y", "y_scale", "y_zp"]);
     let model = load_onnx_model(&bytes).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("x".to_string(), input.clone());
     let result = run_onnx_model(&model, feed).unwrap();
 
@@ -292,7 +292,7 @@ fn qlinear_conv_dequant_conv_quant_round_trip() {
         vec!["y"],
     );
     let model = load_onnx_model(&bytes).unwrap();
-    let result = run_onnx_model(&model, HashMap::new()).unwrap();
+    let result = run_onnx_model(&model, FxHashMap::default()).unwrap();
     let out = result["y"].data();
 
     // With unit scales and identity weight, output == clamp(input, -128, 127).
@@ -339,7 +339,7 @@ fn qlinear_matmul_dequant_matmul_quant_round_trip() {
         vec!["y"],
     );
     let model = load_onnx_model(&bytes).unwrap();
-    let result = run_onnx_model(&model, HashMap::new()).unwrap();
+    let result = run_onnx_model(&model, FxHashMap::default()).unwrap();
     let out = result["y"].data();
 
     // Reference: plain 2×3 × 3×2 matmul, clamped.
@@ -383,7 +383,7 @@ fn matmul_integer_treats_inputs_as_offset_quantized_int_matmul() {
         vec!["y"],
     );
     let model = load_onnx_model(&bytes).unwrap();
-    let result = run_onnx_model(&model, HashMap::new()).unwrap();
+    let result = run_onnx_model(&model, FxHashMap::default()).unwrap();
     // After zero-point subtraction A becomes [[0,1],[2,3]], B is identity.
     // Result: [[0,1],[2,3]].
     assert_close(result["y"].data(), &[0.0, 1.0, 2.0, 3.0], 1e-5);
@@ -572,7 +572,7 @@ fn resize_nearest_neighbour_doubles_spatial() {
     let bytes =
         build_minimal_onnx_model(vec![node], vec![sizes_init], vec!["x", "sizes"], vec!["y"]);
     let model = load_onnx_model(&bytes).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("x".to_string(), input);
     let result = run_onnx_model(&model, feed).unwrap();
     let out = result["y"].data();
@@ -601,7 +601,7 @@ fn upsample_dispatches_through_resize() {
     let bytes =
         build_minimal_onnx_model(vec![node], vec![sizes_init], vec!["x", "sizes"], vec!["y"]);
     let model = load_onnx_model(&bytes).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("x".to_string(), input);
     let result = run_onnx_model(&model, feed).unwrap();
     assert_eq!(result["y"].shape(), &[1, 1, 4, 4]);
@@ -627,7 +627,7 @@ fn conv_transpose_doubles_spatial_with_stride2() {
     };
     let bytes = build_minimal_onnx_model(vec![node], vec![weight], vec!["x", "w"], vec!["y"]);
     let model = load_onnx_model(&bytes).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("x".to_string(), input);
     let result = run_onnx_model(&model, feed).unwrap();
     assert_eq!(result["y"].shape(), &[1, 1, 2, 2]);
@@ -1554,7 +1554,7 @@ fn conv_integer_treats_inputs_as_offset_quantized_int_conv() {
         vec!["y"],
     );
     let model = load_onnx_model(&bytes).unwrap();
-    let result = run_onnx_model(&model, HashMap::new()).unwrap();
+    let result = run_onnx_model(&model, FxHashMap::default()).unwrap();
     // After x_zp subtraction the input is [0,1,2,3], 1×1 identity conv yields
     // exactly that.
     assert_close(result["y"].data(), &[0.0, 1.0, 2.0, 3.0], 1e-5);

--- a/crates/yscv-onnx/src/tests/dynamic_shapes.rs
+++ b/crates/yscv-onnx/src/tests/dynamic_shapes.rs
@@ -85,7 +85,7 @@ fn run_dynamic_cnn(model: &crate::loader::OnnxModel, batch: usize) -> Tensor {
     // Input: [batch, 1, 4, 4]
     let input_data: Vec<f32> = (0..batch * 16).map(|v| (v % 16) as f32 / 16.0).collect();
     let input = Tensor::from_vec(vec![batch, 1, 4, 4], input_data).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("input".to_string(), input);
     let result = run_onnx_model(model, feed).unwrap();
     result["output"].clone()
@@ -213,7 +213,7 @@ fn dynamic_batch_conv_bn_pool() {
 
     // batch=1: input [1,1,4,4] -> conv same-pad [1,2,4,4] -> bn [1,2,4,4] -> pool [1,2,2,2]
     let input1 = Tensor::from_vec(vec![1, 1, 4, 4], (0..16).map(|i| i as f32).collect()).unwrap();
-    let mut feed1 = HashMap::new();
+    let mut feed1 = FxHashMap::default();
     feed1.insert("x".to_string(), input1);
     let r1 = run_onnx_model(&model, feed1).unwrap();
     let y1 = &r1["y"];
@@ -222,7 +222,7 @@ fn dynamic_batch_conv_bn_pool() {
     // batch=3
     let input3 =
         Tensor::from_vec(vec![3, 1, 4, 4], (0..48).map(|i| (i % 16) as f32).collect()).unwrap();
-    let mut feed3 = HashMap::new();
+    let mut feed3 = FxHashMap::default();
     feed3.insert("x".to_string(), input3);
     let r3 = run_onnx_model(&model, feed3).unwrap();
     let y3 = &r3["y"];

--- a/crates/yscv-onnx/src/tests/exporter.rs
+++ b/crates/yscv-onnx/src/tests/exporter.rs
@@ -3,7 +3,7 @@ use crate::exporter::{
     OnnxExportAttr, OnnxExportGraph, OnnxExportNode, OnnxExportValueInfo, export_onnx_model,
 };
 use crate::loader::{OnnxModel, OnnxNode};
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 #[test]
 fn export_roundtrip_relu_graph() {
@@ -33,7 +33,7 @@ fn export_roundtrip_relu_graph() {
     assert_eq!(model.nodes[0].op_type, "Relu");
 
     let input = Tensor::from_vec(vec![1, 4], vec![-1.0, 2.0, -3.0, 4.0]).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("x".to_string(), input);
     let result = run_onnx_model(&model, feed).unwrap();
     assert_eq!(result["y"].data(), &[0.0, 2.0, 0.0, 4.0]);
@@ -68,7 +68,7 @@ fn export_roundtrip_gemm_with_weights() {
     let model = load_onnx_model(&bytes).unwrap();
 
     let input = Tensor::from_vec(vec![1, 3], vec![1.0, 2.0, 3.0]).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("x".to_string(), input);
     let result = run_onnx_model(&model, feed).unwrap();
     let out = &result["y"];
@@ -110,7 +110,7 @@ fn export_to_file_roundtrip() {
 
 #[test]
 fn onnx_model_export_unpermutes_internal_conv_layouts() {
-    let mut initializers = HashMap::new();
+    let mut initializers = FxHashMap::default();
     // Regular Conv internal KHWC [KH, KW, IC, OC] -> ONNX OIHW [OC, IC, KH, KW].
     initializers.insert(
         "regular".to_string(),
@@ -140,7 +140,7 @@ fn onnx_model_export_unpermutes_internal_conv_layouts() {
             name: "conv".to_string(),
             inputs: vec!["x".to_string(), "regular".to_string()],
             outputs: vec!["y".to_string()],
-            attributes: HashMap::new(),
+            attributes: FxHashMap::default(),
         }],
         khwc_weights: Default::default(),
         dw_khwc_weights: Default::default(),
@@ -189,7 +189,7 @@ fn onnx_model_export_unpermutes_internal_conv_layouts() {
 
 #[test]
 fn export_graph_defuses_relu_annotations_and_loads_int8_initializers() {
-    let mut initializers = HashMap::new();
+    let mut initializers = FxHashMap::default();
     initializers.insert(
         "w_q".to_string(),
         Tensor::from_vec(vec![4], vec![-128.0, -2.0, 3.0, 127.0]).unwrap(),
@@ -211,7 +211,7 @@ fn export_graph_defuses_relu_annotations_and_loads_int8_initializers() {
             name: "conv_relu".to_string(),
             inputs: vec!["x".to_string(), "w_q".to_string()],
             outputs: vec!["y".to_string()],
-            attributes: HashMap::new(),
+            attributes: FxHashMap::default(),
         }],
         khwc_weights: Default::default(),
         dw_khwc_weights: Default::default(),

--- a/crates/yscv-onnx/src/tests/fusion_silu.rs
+++ b/crates/yscv-onnx/src/tests/fusion_silu.rs
@@ -125,7 +125,7 @@ fn run_conv_silu_graph(
     let model = load_onnx_model(&bytes).unwrap();
 
     let input_tensor = Tensor::from_vec(input_shape.to_vec(), input_data.clone()).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("x".to_string(), input_tensor);
     let result = run_onnx_model(&model, feed).unwrap();
     let actual = result["y"].data().to_vec();

--- a/crates/yscv-onnx/src/tests/integration.rs
+++ b/crates/yscv-onnx/src/tests/integration.rs
@@ -91,7 +91,7 @@ fn exec_synthetic_cnn_conv_relu_pool_flatten_gemm() {
 
     let input_data: Vec<f32> = (0..16).map(|v| v as f32 / 16.0).collect();
     let input = Tensor::from_vec(vec![1, 1, 4, 4], input_data).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("input".to_string(), input);
 
     let result = run_onnx_model(&model, feed).unwrap();
@@ -155,7 +155,7 @@ fn conv_identity_relu_bridge_fuses_and_matches_relu_output() {
     let model = load_onnx_model(&bytes).unwrap();
 
     let input = Tensor::from_vec(vec![1, 1, 2, 2], vec![0.0, 0.4, 1.0, -2.0]).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("input".to_string(), input);
 
     let result = run_onnx_model(&model, feed).unwrap();
@@ -245,7 +245,7 @@ fn constant_tensor_proto_value_attribute() {
     let model = load_onnx_model(&bytes).unwrap();
 
     let input = Tensor::from_vec(vec![1, 8], (0..8).map(|i| i as f32).collect()).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("input".to_string(), input);
 
     let result = run_onnx_model(&model, feed).unwrap();
@@ -285,7 +285,7 @@ fn split_opset13_input_tensor_sizes() {
     let model = load_onnx_model(&bytes).unwrap();
 
     let input = Tensor::from_vec(vec![1, 6], vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0]).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("input".to_string(), input);
 
     let result = run_onnx_model(&model, feed).unwrap();
@@ -397,7 +397,7 @@ fn scalar_initializer_gather_unsqueeze_concat() {
     // Concat with [4.0] → [2.0, 4.0]
     // Reshape [1, 2, 2, 2] (8 elements) as [2, 4]
     let input = Tensor::from_vec(vec![1, 2, 2, 2], (0..8).map(|i| i as f32).collect()).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("input".to_string(), input);
 
     let result = run_onnx_model(&model, feed).unwrap();
@@ -485,7 +485,7 @@ fn yolo_like_conv_silu_reshape_transpose() {
 
     let input_data: Vec<f32> = (0..16).map(|v| v as f32 / 16.0).collect();
     let input = Tensor::from_vec(vec![1, 1, 4, 4], input_data).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("input".to_string(), input);
 
     let result = run_onnx_model(&model, feed).unwrap();

--- a/crates/yscv-onnx/src/tests/mod.rs
+++ b/crates/yscv-onnx/src/tests/mod.rs
@@ -18,7 +18,7 @@ use prost::Message;
 use super::loader::{OnnxAttribute, load_onnx_model};
 use super::proto::onnx;
 use super::runner::run_onnx_model;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use yscv_tensor::Tensor;
 
 pub(super) fn build_minimal_onnx_model(
@@ -90,7 +90,7 @@ pub(super) fn run_single_op(
     let bytes =
         build_minimal_onnx_model(vec![node], init_protos, all_input_names, vec![output_name]);
     let model = load_onnx_model(&bytes).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     for (name, tensor) in inputs {
         feed.insert(name.to_string(), tensor);
     }

--- a/crates/yscv-onnx/src/tests/normalization.rs
+++ b/crates/yscv-onnx/src/tests/normalization.rs
@@ -52,7 +52,7 @@ fn exec_batch_norm_identity() {
         vec!["y"],
     );
     let model = load_onnx_model(&bytes).unwrap();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert("x".to_string(), input.clone());
     let result = run_onnx_model(&model, feed).unwrap();
     let output = &result["y"];

--- a/crates/yscv-onnx/src/tests/qlinear.rs
+++ b/crates/yscv-onnx/src/tests/qlinear.rs
@@ -135,7 +135,7 @@ fn qlinear_matching_dq_relu_q_runs_in_quant_domain() {
         "matching DQ->Relu->Q should be represented as a quant-domain runtime action"
     );
 
-    let result = run_onnx_model(&model, HashMap::new()).unwrap();
+    let result = run_onnx_model(&model, FxHashMap::default()).unwrap();
     assert_eq!(
         result["yq"].data(),
         &[0.0, 0.0, 0.0, 3.0, 7.0, 0.0, 2.0, 1.0]
@@ -168,7 +168,7 @@ fn qlinear_matmul_symmetric_fast_path_with_nontrivial_scales() {
         0.0,
     );
     let model = load_onnx_model(&bytes).unwrap();
-    let result = run_onnx_model(&model, HashMap::new()).unwrap();
+    let result = run_onnx_model(&model, FxHashMap::default()).unwrap();
     let out = result["y"].data();
 
     let composite = 0.05_f32 * 0.1 / 0.25;
@@ -268,7 +268,7 @@ fn qlinear_conv_symmetric_fast_path_with_bias() {
     );
     let model = load_onnx_model(&bytes).unwrap();
     crate::runner::reset_quant_runtime_stats();
-    let result = run_onnx_model(&model, HashMap::new()).unwrap();
+    let result = run_onnx_model(&model, FxHashMap::default()).unwrap();
     let stats = crate::runner::quant_runtime_stats();
     assert_eq!(stats.qlinear_conv_fast, 1);
     assert_eq!(stats.qlinear_conv_fallback, 0);
@@ -398,7 +398,7 @@ fn check_qlinear_depthwise_with_bias(
         vec!["y"],
     );
     let model = load_onnx_model(&bytes).unwrap();
-    let result = run_onnx_model(&model, HashMap::new()).unwrap();
+    let result = run_onnx_model(&model, FxHashMap::default()).unwrap();
     let out = result["y"].data();
 
     let composite = x_scale * w_scale / y_scale;
@@ -457,7 +457,7 @@ fn matmul_integer_symmetric_fast_path() {
     };
     let bytes = build_minimal_onnx_model(vec![node], inits, vec!["a", "b"], vec!["y"]);
     let model = load_onnx_model(&bytes).unwrap();
-    let result = run_onnx_model(&model, HashMap::new()).unwrap();
+    let result = run_onnx_model(&model, FxHashMap::default()).unwrap();
     let out = result["y"].data();
 
     let mut expected = [0.0_f32; 9];
@@ -517,7 +517,7 @@ fn conv_integer_symmetric_fast_path() {
     };
     let bytes = build_minimal_onnx_model(vec![node], inits, vec!["x", "w"], vec!["y"]);
     let model = load_onnx_model(&bytes).unwrap();
-    let result = run_onnx_model(&model, HashMap::new()).unwrap();
+    let result = run_onnx_model(&model, FxHashMap::default()).unwrap();
     let out = result["y"].data();
 
     let mut expected = vec![0.0_f32; c_out * h * w];
@@ -578,7 +578,7 @@ fn packed_int4_matmul_routes_through_gemv() {
 
     // Reference fp32 forward.
     let activation: Vec<f32> = (0..k).map(|i| ((i as f32) - 32.0) * 0.05).collect();
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert(
         "x".to_string(),
         Tensor::from_vec(vec![1, k], activation.clone()).unwrap(),
@@ -593,7 +593,7 @@ fn packed_int4_matmul_routes_through_gemv() {
     assert!(!model.initializers.contains_key("w"));
     assert!(model.packed_int4_weights.contains_key("w"));
 
-    let mut feed = HashMap::new();
+    let mut feed = FxHashMap::default();
     feed.insert(
         "x".to_string(),
         Tensor::from_vec(vec![1, k], activation).unwrap(),
@@ -792,7 +792,7 @@ fn quantized_pw_dw_chain_bitwise_matches_unfused() {
         );
 
         let x_tensor = Tensor::from_vec(vec![1, c_in, h, w], x_data.clone()).unwrap();
-        let mut feed = HashMap::new();
+        let mut feed = FxHashMap::default();
         feed.insert("x".to_string(), x_tensor);
 
         // Toggle the fast-path env var around two model runs. This
@@ -1018,7 +1018,7 @@ fn quantized_dw_pw_chain_bitwise_matches_unfused() {
         );
 
         let x_tensor = Tensor::from_vec(vec![1, c_in, h, w], x_data.clone()).unwrap();
-        let mut feed = HashMap::new();
+        let mut feed = FxHashMap::default();
         feed.insert("x".to_string(), x_tensor);
 
         #[allow(unsafe_code)]
@@ -1084,7 +1084,7 @@ fn qlinear_matmul_asymmetric_uses_fp32_fallback() {
         0.0,
     );
     let model = load_onnx_model(&bytes).unwrap();
-    let result = run_onnx_model(&model, HashMap::new()).unwrap();
+    let result = run_onnx_model(&model, FxHashMap::default()).unwrap();
     assert_eq!(result["y"].shape(), &[2, 2]);
     // Verify finite output — the asymmetric path's exact numerics are
     // covered by the orphan coverage suite; here we only confirm the

--- a/crates/yscv-optim/Cargo.toml
+++ b/crates/yscv-optim/Cargo.toml
@@ -15,6 +15,7 @@ yscv-autograd = { version = "0.1", path = "../yscv-autograd" }
 yscv-cpu = { version = "0.1", path = "../yscv-cpu" }
 yscv-tensor = { version = "0.1", path = "../yscv-tensor" }
 thiserror.workspace = true
+rustc-hash.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/yscv-optim/src/adagrad.rs
+++ b/crates/yscv-optim/src/adagrad.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::collections::hash_map::Entry;
 
 use yscv_autograd::{Graph, NodeId};
@@ -31,7 +31,7 @@ pub struct Adagrad {
     lr: f32,
     epsilon: f32,
     weight_decay: f32,
-    state: HashMap<u64, AdagradState>,
+    state: FxHashMap<u64, AdagradState>,
 }
 
 impl Adagrad {
@@ -42,7 +42,7 @@ impl Adagrad {
             lr,
             epsilon: 1e-10,
             weight_decay: 0.0,
-            state: HashMap::new(),
+            state: FxHashMap::default(),
         })
     }
 

--- a/crates/yscv-optim/src/adam.rs
+++ b/crates/yscv-optim/src/adam.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::collections::hash_map::Entry;
 
 use yscv_autograd::{Graph, NodeId};
@@ -37,7 +37,7 @@ pub struct Adam {
     beta2: f32,
     epsilon: f32,
     weight_decay: f32,
-    state: HashMap<u64, AdamState>,
+    state: FxHashMap<u64, AdamState>,
 }
 
 impl Adam {
@@ -50,7 +50,7 @@ impl Adam {
             beta2: 0.999,
             epsilon: 1e-8,
             weight_decay: 0.0,
-            state: HashMap::new(),
+            state: FxHashMap::default(),
         })
     }
 

--- a/crates/yscv-optim/src/adamw.rs
+++ b/crates/yscv-optim/src/adamw.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::collections::hash_map::Entry;
 
 use yscv_autograd::{Graph, NodeId};
@@ -37,7 +37,7 @@ pub struct AdamW {
     beta2: f32,
     epsilon: f32,
     weight_decay: f32,
-    state: HashMap<u64, AdamWState>,
+    state: FxHashMap<u64, AdamWState>,
 }
 
 impl AdamW {
@@ -50,7 +50,7 @@ impl AdamW {
             beta2: 0.999,
             epsilon: 1e-8,
             weight_decay: 0.0,
-            state: HashMap::new(),
+            state: FxHashMap::default(),
         })
     }
 

--- a/crates/yscv-optim/src/lamb.rs
+++ b/crates/yscv-optim/src/lamb.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::collections::hash_map::Entry;
 
 use yscv_autograd::{Graph, NodeId};
@@ -40,7 +40,7 @@ pub struct Lamb {
     beta2: f32,
     epsilon: f32,
     weight_decay: f32,
-    state: HashMap<u64, LambState>,
+    state: FxHashMap<u64, LambState>,
 }
 
 impl Lamb {
@@ -53,7 +53,7 @@ impl Lamb {
             beta2: 0.999,
             epsilon: 1e-6,
             weight_decay: 0.0,
-            state: HashMap::new(),
+            state: FxHashMap::default(),
         })
     }
 

--- a/crates/yscv-optim/src/lars.rs
+++ b/crates/yscv-optim/src/lars.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::collections::hash_map::Entry;
 
 use yscv_autograd::{Graph, NodeId};
@@ -17,7 +17,7 @@ pub struct Lars {
     momentum: f32,
     weight_decay: f32,
     trust_coefficient: f32,
-    velocity: HashMap<u64, Tensor>,
+    velocity: FxHashMap<u64, Tensor>,
 }
 
 impl Lars {
@@ -29,7 +29,7 @@ impl Lars {
             momentum: 0.0,
             weight_decay: 0.0,
             trust_coefficient: 0.001,
-            velocity: HashMap::new(),
+            velocity: FxHashMap::default(),
         })
     }
 

--- a/crates/yscv-optim/src/lookahead.rs
+++ b/crates/yscv-optim/src/lookahead.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use yscv_tensor::Tensor;
 
@@ -57,7 +57,7 @@ pub struct Lookahead<O> {
     alpha: f32,
     k: usize,
     step_count: usize,
-    slow_weights: HashMap<u64, Vec<f32>>,
+    slow_weights: FxHashMap<u64, Vec<f32>>,
 }
 
 impl<O: StepOptimizer> Lookahead<O> {
@@ -71,7 +71,7 @@ impl<O: StepOptimizer> Lookahead<O> {
             alpha,
             k,
             step_count: 0,
-            slow_weights: HashMap::new(),
+            slow_weights: FxHashMap::default(),
         }
     }
 

--- a/crates/yscv-optim/src/radam.rs
+++ b/crates/yscv-optim/src/radam.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::collections::hash_map::Entry;
 
 use yscv_autograd::{Graph, NodeId};
@@ -37,7 +37,7 @@ pub struct RAdam {
     beta2: f32,
     epsilon: f32,
     weight_decay: f32,
-    state: HashMap<u64, RAdamState>,
+    state: FxHashMap<u64, RAdamState>,
 }
 
 impl RAdam {
@@ -50,7 +50,7 @@ impl RAdam {
             beta2: 0.999,
             epsilon: 1e-8,
             weight_decay: 0.0,
-            state: HashMap::new(),
+            state: FxHashMap::default(),
         })
     }
 

--- a/crates/yscv-optim/src/rmsprop.rs
+++ b/crates/yscv-optim/src/rmsprop.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::collections::hash_map::Entry;
 
 use yscv_autograd::{Graph, NodeId};
@@ -38,7 +38,7 @@ pub struct RmsProp {
     weight_decay: f32,
     momentum: f32,
     centered: bool,
-    state: HashMap<u64, RmsPropState>,
+    state: FxHashMap<u64, RmsPropState>,
 }
 
 impl RmsProp {
@@ -52,7 +52,7 @@ impl RmsProp {
             weight_decay: 0.0,
             momentum: 0.0,
             centered: false,
-            state: HashMap::new(),
+            state: FxHashMap::default(),
         })
     }
 

--- a/crates/yscv-optim/src/sgd.rs
+++ b/crates/yscv-optim/src/sgd.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::collections::hash_map::Entry;
 
 use yscv_autograd::{Graph, NodeId};
@@ -15,7 +15,7 @@ pub struct Sgd {
     dampening: f32,
     weight_decay: f32,
     nesterov: bool,
-    velocity: HashMap<u64, Tensor>,
+    velocity: FxHashMap<u64, Tensor>,
 }
 
 impl Sgd {
@@ -28,7 +28,7 @@ impl Sgd {
             dampening: 0.0,
             weight_decay: 0.0,
             nesterov: false,
-            velocity: HashMap::new(),
+            velocity: FxHashMap::default(),
         })
     }
 

--- a/crates/yscv-pipeline/Cargo.toml
+++ b/crates/yscv-pipeline/Cargo.toml
@@ -40,6 +40,7 @@ yscv-onnx = { version = "0.1", path = "../yscv-onnx" }
 # deps so we gate this on the feature.
 yscv-video = { version = "0.1", path = "../yscv-video", optional = true }
 thiserror.workspace = true
+rustc-hash.workspace = true
 
 [dev-dependencies]
 

--- a/crates/yscv-pipeline/src/config.rs
+++ b/crates/yscv-pipeline/src/config.rs
@@ -1,8 +1,9 @@
 //! TOML config schema + parsing + validation.
 
 use crate::{Accelerator, ConfigError};
+use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 /// Top-level pipeline configuration parsed from a `boards/*.toml` file.
@@ -120,10 +121,10 @@ pub struct RtSpec {
     /// Per-stage SCHED_FIFO priority. Keys: "capture", "dispatch", "wait",
     /// "encode", "output". Values: 1..=99.
     #[serde(default)]
-    pub prio: HashMap<String, u8>,
+    pub prio: FxHashMap<String, u8>,
     /// Per-stage CPU affinity. Keys same as `prio`; values list of CPU ids.
     #[serde(default)]
-    pub affinity: HashMap<String, Vec<u32>>,
+    pub affinity: FxHashMap<String, Vec<u32>>,
     /// CPU frequency governor to write to every
     /// `/sys/devices/system/cpu/cpu*/cpufreq/scaling_governor`. Leave
     /// unset (or `None` in code) to leave the system default. Most
@@ -185,7 +186,7 @@ impl PipelineConfig {
         }
 
         // Task name uniqueness.
-        let mut seen: HashSet<&str> = HashSet::new();
+        let mut seen: FxHashSet<&str> = FxHashSet::default();
         for task in &self.tasks {
             if !seen.insert(task.name.as_str()) {
                 return Err(ConfigError::InvalidField(format!(
@@ -197,7 +198,7 @@ impl PipelineConfig {
 
         // Dangling input refs: every input source must be either the literal
         // "camera" or "<existing_task>.<anything>".
-        let task_names: HashSet<&str> = self.tasks.iter().map(|t| t.name.as_str()).collect();
+        let task_names: FxHashSet<&str> = self.tasks.iter().map(|t| t.name.as_str()).collect();
         for task in &self.tasks {
             for binding in &task.inputs {
                 let src = binding.source.as_str();
@@ -395,14 +396,14 @@ fn validate_onnx_model(
 fn detect_cycles(tasks: &[InferenceTask]) -> Result<(), ConfigError> {
     // Build adjacency: task name → list of upstream tasks (those whose
     // outputs we depend on).
-    let by_name: HashMap<&str, &InferenceTask> =
+    let by_name: FxHashMap<&str, &InferenceTask> =
         tasks.iter().map(|t| (t.name.as_str(), t)).collect();
-    let mut state: HashMap<&str, u8> = HashMap::new(); // 0=white, 1=gray, 2=black
+    let mut state: FxHashMap<&str, u8> = FxHashMap::default(); // 0=white, 1=gray, 2=black
 
     fn visit<'a>(
         node: &'a str,
-        by_name: &HashMap<&'a str, &'a InferenceTask>,
-        state: &mut HashMap<&'a str, u8>,
+        by_name: &FxHashMap<&'a str, &'a InferenceTask>,
+        state: &mut FxHashMap<&'a str, u8>,
     ) -> Result<(), ConfigError> {
         match state.get(node) {
             Some(&2) => return Ok(()),

--- a/crates/yscv-pipeline/src/dispatch.rs
+++ b/crates/yscv-pipeline/src/dispatch.rs
@@ -29,7 +29,7 @@
 //! **config-driven** path, optimised for correctness and uniformity,
 //! not for sub-millisecond hot loops.
 
-use std::collections::HashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use crate::accelerator::Accelerator;
 use crate::config::InferenceTask;
@@ -139,7 +139,7 @@ struct CpuDispatcher {
     model: yscv_onnx::OnnxModel,
     /// Per-input shape snapshot (from the model's `input_info`), so
     /// `dispatch` can reshape raw bytes into proper tensors.
-    input_shapes: HashMap<String, Vec<usize>>,
+    input_shapes: FxHashMap<String, Vec<usize>>,
 }
 
 impl CpuDispatcher {
@@ -157,7 +157,7 @@ impl CpuDispatcher {
         Ok(Self {
             label: format!("cpu ({})", task.name),
             model,
-            input_shapes: HashMap::new(),
+            input_shapes: FxHashMap::default(),
         })
     }
 }
@@ -168,7 +168,8 @@ impl AcceleratorDispatcher for CpuDispatcher {
     }
 
     fn dispatch(&self, inputs: &[(&str, &[u8])]) -> Result<Vec<(String, Vec<u8>)>, Error> {
-        let mut feed: HashMap<String, yscv_tensor::Tensor> = HashMap::with_capacity(inputs.len());
+        let mut feed: FxHashMap<String, yscv_tensor::Tensor> =
+            FxHashMap::with_capacity_and_hasher(inputs.len(), FxBuildHasher);
         for &(name, bytes) in inputs {
             if bytes.len() % 4 != 0 {
                 return Err(Error::Other(format!(
@@ -671,8 +672,8 @@ impl AcceleratorDispatcher for GpuDispatcher {
 
     fn dispatch(&self, inputs: &[(&str, &[u8])]) -> Result<Vec<(String, Vec<u8>)>, Error> {
         // Same f32-LE byte contract as the other dispatchers.
-        let mut feed: std::collections::HashMap<String, yscv_tensor::Tensor> =
-            std::collections::HashMap::with_capacity(inputs.len());
+        let mut feed: FxHashMap<String, yscv_tensor::Tensor> =
+            FxHashMap::with_capacity_and_hasher(inputs.len(), FxBuildHasher);
         for &(name, bytes) in inputs {
             if bytes.len() % 4 != 0 {
                 return Err(Error::Other(format!(

--- a/crates/yscv-pipeline/src/scheduler.rs
+++ b/crates/yscv-pipeline/src/scheduler.rs
@@ -8,7 +8,8 @@
 use crate::config::{InferenceTask, PipelineConfig};
 use crate::dispatch::{AcceleratorDispatcher, dispatcher_for};
 use crate::error::{ConfigError, Error};
-use std::collections::{HashMap, HashSet};
+use rustc_hash::FxHashSet;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 
 /// Topologically-sorted task list: produces an execution order such that
 /// every task appears after all its dependencies.
@@ -19,7 +20,7 @@ pub struct TaskScheduler {
     pub order: Vec<String>,
     /// Per-task list of upstream task names (inputs whose source is
     /// `<task>.<output>`).
-    pub deps: HashMap<String, Vec<String>>,
+    pub deps: FxHashMap<String, Vec<String>>,
 }
 
 impl TaskScheduler {
@@ -28,7 +29,7 @@ impl TaskScheduler {
     /// `PipelineConfig::validate_self` was called first, but cheap to
     /// double-check).
     pub fn from_config(cfg: &PipelineConfig) -> Result<Self, ConfigError> {
-        let mut deps: HashMap<String, Vec<String>> = HashMap::new();
+        let mut deps: FxHashMap<String, Vec<String>> = FxHashMap::default();
         for task in &cfg.tasks {
             let mut up: Vec<String> = Vec::new();
             for binding in &task.inputs {
@@ -52,7 +53,7 @@ impl TaskScheduler {
 
     /// Identifies tasks safe to run in parallel — those with all
     /// dependencies already satisfied. Used by a future parallel runtime.
-    pub fn ready_tasks(&self, completed: &HashSet<String>) -> Vec<String> {
+    pub fn ready_tasks(&self, completed: &FxHashSet<String>) -> Vec<String> {
         self.order
             .iter()
             .filter(|name| {
@@ -72,15 +73,15 @@ impl TaskScheduler {
 /// every task follows all its dependencies.
 fn topo_sort(
     tasks: &[InferenceTask],
-    deps: &HashMap<String, Vec<String>>,
+    deps: &FxHashMap<String, Vec<String>>,
 ) -> Result<Vec<String>, ConfigError> {
-    let mut state: HashMap<String, u8> = HashMap::new();
+    let mut state: FxHashMap<String, u8> = FxHashMap::default();
     let mut order = Vec::with_capacity(tasks.len());
 
     fn visit(
         node: &str,
-        deps: &HashMap<String, Vec<String>>,
-        state: &mut HashMap<String, u8>,
+        deps: &FxHashMap<String, Vec<String>>,
+        state: &mut FxHashMap<String, u8>,
         order: &mut Vec<String>,
     ) -> Result<(), ConfigError> {
         match state.get(node) {
@@ -115,11 +116,11 @@ pub struct PipelineHandle {
     /// Computed execution order at construction.
     pub order: Vec<String>,
     /// One dispatcher per task, keyed by task name.
-    dispatchers: HashMap<String, Box<dyn AcceleratorDispatcher>>,
+    dispatchers: FxHashMap<String, Box<dyn AcceleratorDispatcher>>,
     /// Canonical task metadata (inputs + outputs bindings) so
     /// `dispatch_frame` can route tensor names from upstream task
     /// outputs into downstream task inputs.
-    tasks: HashMap<String, InferenceTask>,
+    tasks: FxHashMap<String, InferenceTask>,
 }
 
 impl PipelineHandle {
@@ -136,12 +137,13 @@ impl PipelineHandle {
     pub fn dispatch_frame(
         &self,
         camera_inputs: &[(&str, &[u8])],
-    ) -> Result<HashMap<String, Vec<u8>>, Error> {
+    ) -> Result<FxHashMap<String, Vec<u8>>, Error> {
         // Accumulator: scratch buffer of every tensor produced so far.
         // Key format:
         //   - "camera.<name>" for camera ingress
         //   - "<task>.<output_name>" for task outputs
-        let mut world: HashMap<String, Vec<u8>> = HashMap::with_capacity(camera_inputs.len() * 2);
+        let mut world: FxHashMap<String, Vec<u8>> =
+            FxHashMap::with_capacity_and_hasher(camera_inputs.len() * 2, FxBuildHasher);
         for (name, bytes) in camera_inputs {
             world.insert(format!("camera.{name}"), bytes.to_vec());
             // Also expose under bare "camera" so single-input tasks
@@ -338,9 +340,10 @@ pub fn run_pipeline(cfg: PipelineConfig) -> Result<PipelineHandle, Error> {
         );
     }
 
-    let mut dispatchers: HashMap<String, Box<dyn AcceleratorDispatcher>> =
-        HashMap::with_capacity(cfg.tasks.len());
-    let mut tasks: HashMap<String, InferenceTask> = HashMap::with_capacity(cfg.tasks.len());
+    let mut dispatchers: FxHashMap<String, Box<dyn AcceleratorDispatcher>> =
+        FxHashMap::with_capacity_and_hasher(cfg.tasks.len(), FxBuildHasher);
+    let mut tasks: FxHashMap<String, InferenceTask> =
+        FxHashMap::with_capacity_and_hasher(cfg.tasks.len(), FxBuildHasher);
     for task in &cfg.tasks {
         let d = dispatcher_for(task)?;
         dispatchers.insert(task.name.clone(), d);
@@ -503,7 +506,7 @@ mod tests {
             },
         ];
         let sched = TaskScheduler::from_config(&cfg_with(tasks)).unwrap();
-        let mut done: HashSet<String> = HashSet::new();
+        let mut done: FxHashSet<String> = FxHashSet::default();
         let ready_initial = sched.ready_tasks(&done);
         assert!(ready_initial.contains(&"a".to_string()));
         assert!(!ready_initial.contains(&"b".to_string()));

--- a/crates/yscv-quantize-cli/Cargo.toml
+++ b/crates/yscv-quantize-cli/Cargo.toml
@@ -20,6 +20,7 @@ yscv-tensor = { version = "0.1", path = "../yscv-tensor" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror.workspace = true
+rustc-hash.workspace = true
 
 [lints]
 workspace = true

--- a/crates/yscv-quantize-cli/src/main.rs
+++ b/crates/yscv-quantize-cli/src/main.rs
@@ -34,7 +34,7 @@
 //! {"input": {"shape": [1, 3, 224, 224], "values": [0.1, 0.2, ...]}}
 //! ```
 
-use std::collections::HashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 use std::path::PathBuf;
 use std::process::ExitCode;
 
@@ -166,8 +166,8 @@ struct SampleTensor {
 }
 
 /// Read calibration samples from a JSONL file. Each line is a
-/// `HashMap<String, SampleTensor>` mapping graph-input names to tensors.
-fn read_calibration(path: &PathBuf) -> Result<Vec<HashMap<String, Tensor>>, CliError> {
+/// `FxHashMap<String, SampleTensor>` mapping graph-input names to tensors.
+fn read_calibration(path: &PathBuf) -> Result<Vec<FxHashMap<String, Tensor>>, CliError> {
     let text = std::fs::read_to_string(path).map_err(|e| CliError::Io {
         path: path.clone(),
         source: e,
@@ -178,12 +178,12 @@ fn read_calibration(path: &PathBuf) -> Result<Vec<HashMap<String, Tensor>>, CliE
         if line.is_empty() || line.starts_with('#') {
             continue;
         }
-        let parsed: HashMap<String, SampleTensor> =
+        let parsed: FxHashMap<String, SampleTensor> =
             serde_json::from_str(line).map_err(|e| CliError::BadSample {
                 line: idx + 1,
                 message: e.to_string(),
             })?;
-        let mut sample = HashMap::new();
+        let mut sample = FxHashMap::default();
         for (name, st) in parsed {
             let expected: usize = st.shape.iter().product();
             if expected != st.values.len() {
@@ -208,7 +208,7 @@ fn read_calibration(path: &PathBuf) -> Result<Vec<HashMap<String, Tensor>>, CliE
     Ok(samples)
 }
 
-fn read_calibration_spec(spec: &str) -> Result<Vec<HashMap<String, Tensor>>, CliError> {
+fn read_calibration_spec(spec: &str) -> Result<Vec<FxHashMap<String, Tensor>>, CliError> {
     if spec.contains('=') {
         read_paired_calibration(spec)
     } else {
@@ -216,7 +216,7 @@ fn read_calibration_spec(spec: &str) -> Result<Vec<HashMap<String, Tensor>>, Cli
     }
 }
 
-fn read_paired_calibration(spec: &str) -> Result<Vec<HashMap<String, Tensor>>, CliError> {
+fn read_paired_calibration(spec: &str) -> Result<Vec<FxHashMap<String, Tensor>>, CliError> {
     let streams: Vec<(String, PathBuf)> = spec
         .split(',')
         .map(|pair| {
@@ -255,7 +255,7 @@ fn read_paired_calibration(spec: &str) -> Result<Vec<HashMap<String, Tensor>>, C
 
     let mut samples = Vec::with_capacity(expected_len);
     for idx in 0..expected_len {
-        let mut sample = HashMap::with_capacity(parsed.len());
+        let mut sample = FxHashMap::with_capacity_and_hasher(parsed.len(), FxBuildHasher);
         for (name, tensors) in &parsed {
             sample.insert(name.clone(), tensors[idx].clone());
         }
@@ -278,7 +278,7 @@ fn read_single_tensor_stream(name: &str, path: &PathBuf) -> Result<Vec<Tensor>, 
         let st: SampleTensor = match serde_json::from_str(line) {
             Ok(st) => st,
             Err(_) => {
-                let wrapped: HashMap<String, SampleTensor> =
+                let wrapped: FxHashMap<String, SampleTensor> =
                     serde_json::from_str(line).map_err(|e| CliError::BadSample {
                         line: idx + 1,
                         message: e.to_string(),
@@ -355,7 +355,7 @@ fn run(args: Args) -> Result<(), CliError> {
         snap
     } else {
         eprintln!("calibration: weights-only mode, no activation stats collected");
-        HashMap::new()
+        FxHashMap::default()
     };
 
     eprintln!(

--- a/crates/yscv-track/Cargo.toml
+++ b/crates/yscv-track/Cargo.toml
@@ -14,6 +14,7 @@ keywords.workspace = true
 yscv-detect = { version = "0.1", path = "../yscv-detect" }
 yscv-tensor = { version = "0.1", path = "../yscv-tensor" }
 thiserror.workspace = true
+rustc-hash.workspace = true
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }

--- a/crates/yscv-track/src/reid.rs
+++ b/crates/yscv-track/src/reid.rs
@@ -1,6 +1,6 @@
 //! Re-identification feature extraction for DeepSORT appearance matching.
 
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use yscv_tensor::Tensor;
 
@@ -58,7 +58,7 @@ impl ReIdExtractor for ColorHistogramReId {
 /// Re-id feature gallery that stores per-track appearance features
 /// and computes cosine distance for matching.
 pub struct ReIdGallery {
-    features: HashMap<u64, Vec<Vec<f32>>>,
+    features: FxHashMap<u64, Vec<Vec<f32>>>,
     max_features: usize,
 }
 
@@ -66,7 +66,7 @@ impl ReIdGallery {
     /// Create a new gallery that keeps at most `max_features` per track.
     pub fn new(max_features: usize) -> Self {
         Self {
-            features: HashMap::new(),
+            features: FxHashMap::default(),
             max_features,
         }
     }

--- a/crates/yscv-video/Cargo.toml
+++ b/crates/yscv-video/Cargo.toml
@@ -31,6 +31,7 @@ rayon = "1.11"
 yscv-cpu = { version = "0.1", path = "../yscv-cpu" }
 yscv-tensor = { version = "0.1", path = "../yscv-tensor" }
 thiserror.workspace = true
+rustc-hash.workspace = true
 
 # Platform-specific HW decode (linked via system frameworks, no crate deps needed)
 # VideoToolbox: uses raw FFI to CoreMedia/VideoToolbox frameworks (macOS)

--- a/crates/yscv-video/src/tests.rs
+++ b/crates/yscv-video/src/tests.rs
@@ -729,7 +729,7 @@ fn nv12_to_rgb8_non_trivial_values() {
     assert!(sum > 0, "output should not be all zeros");
 
     // Verify output contains distinct values (not all same, indicating real conversion)
-    let distinct: std::collections::HashSet<u8> = out.iter().copied().collect();
+    let distinct: rustc_hash::FxHashSet<u8> = out.iter().copied().collect();
     assert!(distinct.len() > 1, "output should contain distinct values");
 }
 

--- a/crates/yscv-video/src/video_io.rs
+++ b/crates/yscv-video/src/video_io.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::io::{Read, Write};
 use std::path::Path;
 
@@ -13,7 +13,7 @@ pub struct VideoMeta {
     pub height: u32,
     pub frame_count: u32,
     pub fps: f32,
-    pub properties: HashMap<String, String>,
+    pub properties: FxHashMap<String, String>,
 }
 
 /// Reads raw RGB8 frames from a simple uncompressed video file.
@@ -57,7 +57,7 @@ impl RawVideoReader {
                 height,
                 frame_count,
                 fps,
-                properties: HashMap::new(),
+                properties: FxHashMap::default(),
             },
             data,
             frame_offset: 24,

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -25,6 +25,7 @@ yscv-kernels = { path = "../crates/yscv-kernels" }
 yscv-onnx = { path = "../crates/yscv-onnx" }
 yscv-pipeline = { path = "../crates/yscv-pipeline" }
 thiserror.workspace = true
+rustc-hash.workspace = true
 
 [[example]]
 name = "classify_image"

--- a/examples/src/bench_gpu.rs
+++ b/examples/src/bench_gpu.rs
@@ -3,6 +3,7 @@
 //! Usage:
 //!   cargo run --release --example bench_gpu --features gpu -- <model.onnx>
 
+use rustc_hash::FxHashMap;
 use std::collections::HashMap;
 use yscv_kernels::GpuBackend;
 use yscv_onnx::{
@@ -59,7 +60,7 @@ fn main() {
     // Warm-up
     eprintln!("Warm-up...");
     for _ in 0..3 {
-        let mut inputs = HashMap::new();
+        let mut inputs = FxHashMap::default();
         inputs.insert("images".to_string(), input_tensor.clone());
         let _ = run_onnx_model_gpu_cached(&gpu, &model, inputs, &mut wc, Some(&exec_plan))
             .expect("fail");
@@ -70,7 +71,7 @@ fn main() {
     eprintln!("\nBenchmark (cached):");
     let mut times = Vec::new();
     for i in 0..n_runs {
-        let mut inputs = HashMap::new();
+        let mut inputs = FxHashMap::default();
         inputs.insert("images".to_string(), input_tensor.clone());
         let t0 = std::time::Instant::now();
         let _ = run_onnx_model_gpu_cached(&gpu, &model, inputs, &mut wc, Some(&exec_plan))
@@ -91,7 +92,7 @@ fn main() {
     eprintln!("\nBenchmark (uncached, reusing GpuBackend):");
     let mut times2 = Vec::new();
     for i in 0..5 {
-        let mut inputs = HashMap::new();
+        let mut inputs = FxHashMap::default();
         inputs.insert("images".to_string(), input_tensor.clone());
         let t0 = std::time::Instant::now();
         let _ = run_onnx_model_gpu_with(&gpu, &model, inputs).expect("fail");
@@ -106,7 +107,7 @@ fn main() {
 
     if do_profile {
         eprintln!("\nProfiling (sync per op)...");
-        let mut inputs = HashMap::new();
+        let mut inputs = FxHashMap::default();
         inputs.insert("images".to_string(), input_tensor.clone());
         let _ = profile_onnx_model_gpu(&model, inputs).expect("profile failed");
     }

--- a/examples/src/bench_metal_yolo.rs
+++ b/examples/src/bench_metal_yolo.rs
@@ -35,7 +35,7 @@ fn main() {
 
         // ── CPU baseline ──
         let cpu_out = {
-            let mut inp = std::collections::HashMap::new();
+            let mut inp = FxHashMap::default();
             inp.insert("images".to_string(), input_tensor.clone());
             yscv_onnx::run_onnx_model(&model, inp).expect("cpu fail")
         };

--- a/examples/src/bench_vball_cpu.rs
+++ b/examples/src/bench_vball_cpu.rs
@@ -3,9 +3,9 @@
 //! Usage:
 //!   cargo run --release --example bench_vball_cpu -- /path/to/model.onnx [iterations]
 
-use std::collections::HashMap;
 use std::time::Instant;
 
+use rustc_hash::FxHashMap;
 use yscv_onnx::{load_onnx_model_from_file, profile_onnx_model_cpu, run_onnx_model};
 use yscv_tensor::Tensor;
 
@@ -30,14 +30,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Profile
     if std::env::var("PROFILE").is_ok() {
         println!("Profiling...");
-        let mut pinputs = HashMap::new();
+        let mut pinputs = FxHashMap::default();
         pinputs.insert(input_name.clone(), input.clone());
         let _ = profile_onnx_model_cpu(&model, pinputs);
     }
 
     // Warmup
     println!("Warmup...");
-    let mut inputs = HashMap::new();
+    let mut inputs = FxHashMap::default();
     inputs.insert(input_name.clone(), input.clone());
     let _ = run_onnx_model(&model, inputs)?;
 
@@ -45,7 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Running {iterations} iterations...");
     let mut times = Vec::with_capacity(iterations);
     for i in 0..iterations {
-        let mut inputs = HashMap::new();
+        let mut inputs = FxHashMap::default();
         inputs.insert(input_name.clone(), input.clone());
         let t0 = Instant::now();
         let _ = run_onnx_model(&model, inputs)?;

--- a/examples/src/bench_yolo.rs
+++ b/examples/src/bench_yolo.rs
@@ -3,6 +3,7 @@
 //! Set BENCH_COOLDOWN=<secs> to insert a cooldown pause between benchmarks
 //! (default: 20s). This prevents CPU thermal throttling from skewing results.
 
+use rustc_hash::FxHashMap;
 use yscv_onnx::load_onnx_model_from_file;
 use yscv_tensor::Tensor;
 
@@ -45,7 +46,7 @@ fn main() {
         println!("\n  [CPU]");
         #[allow(unused_variables)]
         let cpu_out = {
-            let mut inp = std::collections::HashMap::new();
+            let mut inp = FxHashMap::default();
             inp.insert("images".to_string(), input_tensor.clone());
             yscv_onnx::run_onnx_model(&model, inp).expect("cpu fail")
         };
@@ -55,7 +56,7 @@ fn main() {
 
         {
             println!("\n  [CPU Profile]");
-            let mut inp = std::collections::HashMap::new();
+            let mut inp = FxHashMap::default();
             inp.insert("images".to_string(), input_tensor.clone());
             let _ = yscv_onnx::profile_onnx_model_cpu(&model, inp);
         }
@@ -64,7 +65,7 @@ fn main() {
         #[cfg(feature = "gpu")]
         {
             cooldown("GPU profile");
-            let mut inp = std::collections::HashMap::new();
+            let mut inp = FxHashMap::default();
             inp.insert("images".to_string(), input_tensor.clone());
             let _ = yscv_onnx::profile_onnx_model_gpu(&model, inp);
         }
@@ -80,7 +81,7 @@ fn main() {
             let plan = yscv_onnx::plan_gpu_execution(&model);
 
             // Warmup (populates weight cache)
-            let mut inputs = std::collections::HashMap::new();
+            let mut inputs = FxHashMap::default();
             inputs.insert("images".to_string(), input_tensor.clone());
             let _ =
                 yscv_onnx::run_onnx_model_gpu_cached(&gpu, &model, inputs, &mut wc, Some(&plan));
@@ -90,7 +91,7 @@ fn main() {
             let n = 5;
             let mut times = Vec::new();
             for i in 0..n {
-                let mut inputs = std::collections::HashMap::new();
+                let mut inputs = FxHashMap::default();
                 inputs.insert("images".to_string(), input_tensor.clone());
                 let start = std::time::Instant::now();
                 let result = yscv_onnx::run_onnx_model_gpu_cached(
@@ -400,18 +401,18 @@ fn bench_run(
     input_tensor: &Tensor,
     run_fn: impl Fn(
         &yscv_onnx::OnnxModel,
-        std::collections::HashMap<String, Tensor>,
-    ) -> Result<std::collections::HashMap<String, Tensor>, yscv_onnx::OnnxError>,
+        FxHashMap<String, Tensor>,
+    ) -> Result<FxHashMap<String, Tensor>, yscv_onnx::OnnxError>,
 ) {
     // Warmup
-    let mut inputs = std::collections::HashMap::new();
+    let mut inputs = FxHashMap::default();
     inputs.insert("images".to_string(), input_tensor.clone());
     let _ = run_fn(model, inputs);
 
     let n = 5;
     let mut times = Vec::new();
     for i in 0..n {
-        let mut inputs = std::collections::HashMap::new();
+        let mut inputs = FxHashMap::default();
         inputs.insert("images".to_string(), input_tensor.clone());
         let start = std::time::Instant::now();
         let result = run_fn(model, inputs);

--- a/examples/src/debug_metal_yolo.rs
+++ b/examples/src/debug_metal_yolo.rs
@@ -22,7 +22,7 @@ fn main() {
     let input_tensor = Tensor::from_vec(vec![1, 3, 640, 640], input_data.clone()).unwrap();
 
     // CPU inference
-    let mut cpu_inputs = std::collections::HashMap::new();
+    let mut cpu_inputs = FxHashMap::default();
     cpu_inputs.insert("images".to_string(), input_tensor.clone());
     let cpu_out = yscv_onnx::run_onnx_model(&model, cpu_inputs).expect("cpu");
     let cpu_t = cpu_out.values().next().unwrap();

--- a/examples/src/yolo_detect.rs
+++ b/examples/src/yolo_detect.rs
@@ -27,6 +27,7 @@
 //!   yolo export model=yolov8n.pt format=onnx   # YOLOv8
 //!   yolo export model=yolo11n.pt format=onnx   # YOLOv11
 
+use rustc_hash::FxHashMap;
 use yscv_detect::{
     Detection, coco_labels, decode_yolov8_output, decode_yolov11_output, letterbox_preprocess,
     yolov8_coco_config,
@@ -131,7 +132,7 @@ fn main() {
     {
         println!("\n=== CPU ===");
         println!("Running inference...");
-        let mut inputs = std::collections::HashMap::new();
+        let mut inputs = FxHashMap::default();
         inputs.insert("images".to_string(), input_tensor.clone());
         let outputs = yscv_onnx::run_onnx_model(&model, inputs).expect("Inference failed");
         let output = outputs.values().next().expect("no output");

--- a/examples/src/yolo_vis.rs
+++ b/examples/src/yolo_vis.rs
@@ -113,7 +113,7 @@ fn main() {
     // CPU
     println!("\n=== CPU ===");
     let cpu_dets = {
-        let mut inputs = std::collections::HashMap::new();
+        let mut inputs = FxHashMap::default();
         inputs.insert("images".to_string(), input_tensor.clone());
         let outputs = yscv_onnx::run_onnx_model(&model, inputs).expect("CPU failed");
         let output = outputs.values().next().expect("no output");


### PR DESCRIPTION
`std::collections` hashling algo is cryptographic and randomised; we do not need this. Let's migrate to rustc's `FxHasher`, since it is cheaper in terms of compute
