### PR TITLE
Route the crop_resize ISA checks through yscv-cpu

### DIFF
--- a/crates/yscv-imgproc/src/ops/crop_resize.rs
+++ b/crates/yscv-imgproc/src/ops/crop_resize.rs
@@ -1235,7 +1235,7 @@ mod tests {
                 );
                 #[cfg(target_arch = "x86_64")]
                 unsafe {
-                    if (ch == 1 || ch == 3) && std::is_x86_feature_detected!("avx512f") {
+                    if (ch == 1 || ch == 3) && yscv_cpu::host_cpu().features.avx512f {
                         bitexact(
                             &want,
                             &crop_resize_border_avx512(
@@ -1244,7 +1244,7 @@ mod tests {
                             &lbl,
                         );
                     }
-                    if (ch == 1 || ch == 3) && std::is_x86_feature_detected!("avx2") {
+                    if (ch == 1 || ch == 3) && yscv_cpu::host_cpu().features.avx2 {
                         bitexact(
                             &want,
                             &crop_resize_border_avx2(
@@ -1253,7 +1253,7 @@ mod tests {
                             &lbl,
                         );
                     }
-                    if std::is_x86_feature_detected!("sse4.1") {
+                    if yscv_cpu::host_cpu().features.sse41 {
                         bitexact(
                             &want,
                             &crop_resize_border_sse(
@@ -1311,21 +1311,21 @@ mod tests {
                 // and each individual SIMD path the host supports
                 #[cfg(target_arch = "x86_64")]
                 unsafe {
-                    if (ch == 1 || ch == 3) && std::is_x86_feature_detected!("avx512f") {
+                    if (ch == 1 || ch == 3) && yscv_cpu::host_cpu().features.avx512f {
                         bitexact(
                             &want,
                             &crop_resize_avx512(&src, h, w, ch, cx, cy, ww, wh, tw, th),
                             &lbl,
                         );
                     }
-                    if (ch == 1 || ch == 3) && std::is_x86_feature_detected!("avx2") {
+                    if (ch == 1 || ch == 3) && yscv_cpu::host_cpu().features.avx2 {
                         bitexact(
                             &want,
                             &crop_resize_avx2(&src, h, w, ch, cx, cy, ww, wh, tw, th),
                             &lbl,
                         );
                     }
-                    if std::is_x86_feature_detected!("sse4.1") {
+                    if yscv_cpu::host_cpu().features.sse41 {
                         bitexact(
                             &want,
                             &crop_resize_sse(&src, h, w, ch, cx, cy, ww, wh, tw, th),


### PR DESCRIPTION
`check-runtime-dispatch.sh` has been red on main since the SSE4.1/AVX-512 crop_resize paths landed — six raw `std::is_x86_feature_detected!` calls in the bit-exactness tests. The production dispatch in the same file already uses `yscv_cpu::host_cpu().features`; the tests now do too.

GitHub CI does not run this script, only `check-ci-local.sh` does, which is why it went unnoticed.

`check-ci-local.sh` now exits 0. imgproc suite 247 passed.